### PR TITLE
Cleanup the logic and messages in loadResponseGenerator.

### DIFF
--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -68,7 +68,6 @@ public class DatabaseAdaptorTest {
     Map<String, String> configEntries = new HashMap<String, String>();
     String modeOfOperation = "com.google.enterprise.adaptor.database"
         + ".ResponseGenerator.rowToText";
-    System.out.println("XXX setting " + modeOfOperation);
     configEntries.put("db.modeOfOperation", modeOfOperation);
     final Config config = new Config();
     for (Map.Entry<String, String> entry : configEntries.entrySet()) {

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -64,7 +64,22 @@ public class DatabaseAdaptorTest {
   }
 
   @Test
-  public void testLoadResponseGeneratorWithFullyQualifiedMethod() {
+  public void testLoadResponseGeneratorWithBuiltinFullyQualifiedMethod() {
+    Map<String, String> configEntries = new HashMap<String, String>();
+    String modeOfOperation = "com.google.enterprise.adaptor.database"
+        + ".ResponseGenerator.rowToText";
+    System.out.println("XXX setting " + modeOfOperation);
+    configEntries.put("db.modeOfOperation", modeOfOperation);
+    final Config config = new Config();
+    for (Map.Entry<String, String> entry : configEntries.entrySet()) {
+      TestHelper.setConfigValue(config, entry.getKey(), entry.getValue());
+    }
+    assertNotNull("loaded response generator is null",
+        DatabaseAdaptor.loadResponseGenerator(config));
+  }
+
+  @Test
+  public void testLoadResponseGeneratorWithCustomFullyQualifiedMethod() {
     Map<String, String> configEntries = new HashMap<String, String>();
     String modeOfOperation = "com.google.enterprise.adaptor.database"
         + ".DatabaseAdaptorTest.createDummy";
@@ -87,7 +102,7 @@ public class DatabaseAdaptorTest {
     }
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage(
-        "noThisMethod cannot be parsed as a fully qualified method");
+        "noThisMethod is not a valid built-in modeOfOperation");
     DatabaseAdaptor.loadResponseGenerator(config);
   }
 
@@ -102,6 +117,8 @@ public class DatabaseAdaptorTest {
       TestHelper.setConfigValue(config, entry.getKey(), entry.getValue());
     }
     thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("No method noThisMode found for class "
+        + "com.google.enterprise.adaptor.database.DatabaseAdaptorTest");
     DatabaseAdaptor.loadResponseGenerator(config);
   }
 


### PR DESCRIPTION
* Use Method's introspective methods rather than string manipulation
  to enumerate valid modeOfOperation values.

* Avoid checking for both bare method names in ResponseGenerator and
  fully qualified method names. They are mutually exclusive.

* Do not log messages about trying a fully qualified name before
  checking to see if it's a fully qualified name.