### PR TITLE
Fix "ant run" paths to logging.properties and JDBC drivers.

### DIFF
--- a/build.properties.sample
+++ b/build.properties.sample
@@ -9,3 +9,6 @@ jdk7.home = /Library/Java/JavaVirtualMachines/jdk1.7.0_76.jdk/Contents/Home
 build.bootclasspath = ${jdk7.home}/jre/lib/rt.jar\
     :${jdk7.home}/jre/lib/jsse.jar\
     :${jdk7.home}/jre/lib/jce.jar
+
+# Classpath of JDBC drivers for "ant run".
+jdbc.classpath =

--- a/build.xml
+++ b/build.xml
@@ -28,15 +28,12 @@
   <property name="compile.java.bootclasspath" value="${build.bootclasspath}"/>
 
   <path id="adaptor.build.classpath">
-<!--
-    <fileset dir="${lib.dir}">
-    </fileset>
--->
     <pathelement location="${adaptor.jar}"/>
   </path>
 
   <path id="adaptor.run.classpath">
     <path refid="adaptor.build.classpath"/>
+    <pathelement path="${jdbc.classpath}"/>
   </path>
 
   <path id="cobertura.classpath">
@@ -236,7 +233,7 @@ lib/plexi submodule or add the the command line argument
     <java classpath="${build-src.dir}" fork="true" classname="${adaptor.class}">
       <classpath refid="adaptor.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
-        value="src/logging.properties"/>
+        value="logging.properties"/>
       <sysproperty key="javax.net.ssl.keyStore" file="keys.jks"/>
       <sysproperty key="javax.net.ssl.keyStoreType" value="jks"/>
       <sysproperty key="javax.net.ssl.keyStorePassword" value="changeit"/>


### PR DESCRIPTION
* Fix the reference to logging.properties, moved in commit 0c66f20.

* Add a property to build.properties to specify JDBC drivers.

Any JDBC drivers referenced by db.driverClass in
adaptor-config.properties must be on the class path at runtime,
but there's no provision for that. The commented-out lib
directory reference in adaptor.build.classpath might have been
aimed at that. To avoid requiring changes to files under version
control, switch to using a property from build.properties (as the
Documentum connector does).