### PR TITLE
Use a more realistic query for UniqueKey round trip test.

### DIFF
--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -274,22 +274,17 @@ public class UniqueKeyTest {
         id = uk.makeUniqueId(rs, /*encode=*/ true);
       }
 
-      executeUpdate("delete from data");
-
-      String sql = "insert into data(a, b) values (?, ?)";
+      String sql = "select * from data where a = ? and b = ?";
       try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
         uk.setContentSqlValues(ps, id);
-        assertEquals(1, ps.executeUpdate());
+        try (ResultSet rs = ps.executeQuery()) {
+          assertTrue("ResultSet is empty", rs.next());
+          assertEquals(elem1, rs.getString(1));
+          assertEquals(elem2, rs.getString(2));
+        }
       } catch (Exception e) {
         throw new RuntimeException("elem1: " + elem1 + ", elem2: " + elem2 
             + ", id: " + id, e);
-      }
-
-      try (Statement stmt = getConnection().createStatement();
-          ResultSet rs = stmt.executeQuery("select * from data")) {
-        assertTrue("ResultSet is empty", rs.next());
-        assertEquals(elem1, rs.getString(1));
-        assertEquals(elem2, rs.getString(2));
       }
     } finally {
       dropAllObjects();


### PR DESCRIPTION
The query in the test should mimic db.singleDocContentSql and
successfully fetch the row the unique key was generated from.