### PR TITLE
Do not require urlAndMetadataLister.columnName (b/38283549)

### DIFF
--- a/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
+++ b/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
@@ -29,7 +29,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -352,9 +351,14 @@ public abstract class ResponseGenerator {
     }
   }
 
-  private static class UrlAndMetadataLister extends SingleColumnContent {
+  private static class UrlAndMetadataLister extends ResponseGenerator {
     UrlAndMetadataLister(Map<String, String> config) {
       super(config);
+      String col = getConfig().get("columnName");
+      if (col != null) {
+        log.warning("urlAndMetadataLister mode ignores columnName="
+            + col + " and uses db.uniqueKey to specify the URL.");
+      }
     }
 
     @Override


### PR DESCRIPTION
UrlAndMetadataLister spuriously extended SingleColumnContent instead
of just ResponseGenerator. The URL is specified by db.uniqueKey rather
than db.modeOfOperation.urlAndMetadataLister.columnName.

Other changes:
* Fix lint error.