### PR TITLE
Treat empty modeOfOperation properties as null (b/29425538)

### DIFF
--- a/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
+++ b/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
@@ -62,6 +62,10 @@ public abstract class ResponseGenerator {
   private static final Logger log
       = Logger.getLogger(ResponseGenerator.class.getName());
 
+  private static String emptyToNull(String value) {
+    return (value == null || value.isEmpty()) ? null : value;
+  }
+
   private final Map<String, String> cfg;
   private final String displayUrlCol; // can be null
 
@@ -75,7 +79,7 @@ public abstract class ResponseGenerator {
     }
     this.cfg = Collections.unmodifiableMap(config);
     log.config("entire config map=" + cfg);
-    displayUrlCol = getConfig().get("displayUrlCol");
+    displayUrlCol = emptyToNull(getConfig().get("displayUrlCol"));
     log.config("displayUrlCol=" + displayUrlCol);
   }
 
@@ -168,7 +172,7 @@ public abstract class ResponseGenerator {
     RowToHtml(Map<String, String> config)
         throws TransformerConfigurationException, IOException {
       super(config);
-      String stylesheetFilename = getConfig().get("stylesheet");
+      String stylesheetFilename = emptyToNull(getConfig().get("stylesheet"));
       InputStream xsl = null;
       if (null != stylesheetFilename) {
         xsl = new FileInputStream(stylesheetFilename);
@@ -277,13 +281,15 @@ public abstract class ResponseGenerator {
 
     SingleColumnContent(Map<String, String> config) {
       super(config);
-      col = getConfig().get("columnName"); 
+      col = emptyToNull(getConfig().get("columnName"));
       if (null == col) {
-        throw new NullPointerException("columnName needs to be provided");
+        throw new InvalidConfigurationException(
+            "The modeOfOperation property columnName is required for "
+            + getClass().getSimpleName());
       }
       log.config("col=" + col);
-      contentTypeOverride = getConfig().get("contentTypeOverride");
-      contentTypeCol = getConfig().get("contentTypeCol");
+      contentTypeOverride = emptyToNull(getConfig().get("contentTypeOverride"));
+      contentTypeCol = emptyToNull(getConfig().get("contentTypeCol"));
       log.config("contentTypeOverride=" + contentTypeOverride);
       log.config("contentTypeCol=" + contentTypeCol);
       if (null != contentTypeOverride && null != contentTypeCol) {

--- a/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
+++ b/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
@@ -67,7 +67,7 @@ public class ResponseGeneratorTest {
 
   @Test
   public void testMissingColumnNameForUrlMode() {
-    thrown.expect(NullPointerException.class);
+    thrown.expect(InvalidConfigurationException.class);
     ResponseGenerator.urlColumn(Collections.<String, String>emptyMap());
   }
 
@@ -80,14 +80,35 @@ public class ResponseGeneratorTest {
 
   @Test
   public void testMissingColumnNameForFilepathMode() {
-    thrown.expect(NullPointerException.class);
+    thrown.expect(InvalidConfigurationException.class);
     ResponseGenerator.filepathColumn(Collections.<String, String>emptyMap());
   }
 
   @Test
   public void testMissingColumnNameForBlobMode() {
-    thrown.expect(NullPointerException.class);
+    thrown.expect(InvalidConfigurationException.class);
     ResponseGenerator.contentColumn(Collections.<String, String>emptyMap());
+  }
+
+  @Test
+  public void testEmptyColumnNameForUrlMode() {
+    thrown.expect(InvalidConfigurationException.class);
+    ResponseGenerator.urlColumn(
+        Collections.<String, String>singletonMap("columnName", ""));
+  }
+
+  @Test
+  public void testEmptyColumnNameForFilepathMode() {
+    thrown.expect(InvalidConfigurationException.class);
+    ResponseGenerator.filepathColumn(
+        Collections.<String, String>singletonMap("columnName", ""));
+  }
+
+  @Test
+  public void testEmptyColumnNameForBlobMode() {
+    thrown.expect(InvalidConfigurationException.class);
+    ResponseGenerator.contentColumn(
+        Collections.<String, String>singletonMap("columnName", ""));
   }
 
   private static class MockResponse implements InvocationHandler {
@@ -318,6 +339,7 @@ public class ResponseGeneratorTest {
     Map<String, String> cfg = new TreeMap<String, String>();
     cfg.put("columnName", "content");
     cfg.put("contentTypeOverride", "dev/rubish");
+    cfg.put("contentTypeCol", ""); // Empty should be ignored.
     ResponseGenerator resgen = ResponseGenerator.contentColumn(cfg);
 
     ResultSet rs = executeQueryAndNext("select * from data");
@@ -342,6 +364,7 @@ public class ResponseGeneratorTest {
     Response response = newProxyInstance(Response.class, bar);
     Map<String, String> cfg = new TreeMap<String, String>();
     cfg.put("columnName", "content");
+    cfg.put("contentTypeOverride", ""); // Empty should be ignored.
     cfg.put("contentTypeCol", "contentType");
     ResponseGenerator resgen = ResponseGenerator.contentColumn(cfg);
 
@@ -405,6 +428,7 @@ public class ResponseGeneratorTest {
     Map<String, String> cfg = new TreeMap<String, String>();
     cfg.put("columnName", "content");
     cfg.put("contentTypeOverride", "dev/rubish");
+    cfg.put("contentTypeCol", null); // Null should be ignored.
     ResponseGenerator resgen = ResponseGenerator.contentColumn(cfg);
 
     ResultSet rs = executeQueryAndNext("select * from data");
@@ -429,6 +453,7 @@ public class ResponseGeneratorTest {
     Response response = newProxyInstance(Response.class, bar);
     Map<String, String> cfg = new TreeMap<String, String>();
     cfg.put("columnName", "content");
+    cfg.put("contentTypeOverride", null); // Null should be ignored.
     cfg.put("contentTypeCol", "contentType");
     ResponseGenerator resgen = ResponseGenerator.contentColumn(cfg);
 


### PR DESCRIPTION
Note for reviewer: I intentionally avoiding modifying testMissingColumnNameForUrlAndMetadataListerMode to avoid conflicting with #25, which deletes that test.