### PR TITLE
Include the resources in the class path for "ant run".

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,6 +33,7 @@
 
   <path id="adaptor.run.classpath">
     <path refid="adaptor.build.classpath"/>
+    <pathelement location="${resource.dir}"/>
     <pathelement path="${jdbc.classpath}"/>
   </path>
 


### PR DESCRIPTION
With this, modeOfOperation=rowToHtml fails with
"Default stylesheet not found in resources".