### PR TITLE
Get ResultSetMetaData in buildAcl rather than passing it in.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -363,21 +363,21 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     try {
       statementAndResult = getAclFromDb(conn, uniqueId);
       ResultSet rs = statementAndResult.resultSet;
-      ResultSetMetaData metadata = rs.getMetaData();
-      return buildAcl(rs, metadata, aclPrincipalDelimiter, aclNamespace);
+      return buildAcl(rs, aclPrincipalDelimiter, aclNamespace);
     } finally {
       tryClosingStatementAndResult(statementAndResult);
     }
   }
   
   @VisibleForTesting
-  static Acl buildAcl(ResultSet rs, ResultSetMetaData metadata, String delim,
-      String namespace) throws SQLException {
+  static Acl buildAcl(ResultSet rs, String delim, String namespace)
+      throws SQLException {
     boolean hasResult = rs.next();
     if (!hasResult) {
       // empty Acl ensures adaptor will mark this document as secure
       return Acl.EMPTY;
     }
+    ResultSetMetaData metadata = rs.getMetaData();
     Acl.Builder builder = new Acl.Builder();
     ArrayList<UserPrincipal> permitUsers = new ArrayList<UserPrincipal>();
     ArrayList<UserPrincipal> denyUsers = new ArrayList<UserPrincipal>();

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -22,7 +22,6 @@ import static com.google.enterprise.adaptor.database.JdbcFixture.executeQueryAnd
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeUpdate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import com.google.enterprise.adaptor.Acl;
 import com.google.enterprise.adaptor.Config;
@@ -36,7 +35,6 @@ import com.google.enterprise.adaptor.UserPrincipal;
 import com.google.enterprise.adaptor.database.DatabaseAdaptor.GsaSpecialColumns;
 import java.io.IOException;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -228,8 +226,7 @@ public class DatabaseAdaptorTest {
 
     executeUpdate("create table acl");
     ResultSet rs = executeQuery("select * from acl");
-    ResultSetMetaData metadata = rs.getMetaData();
-    Acl acl = DatabaseAdaptor.buildAcl(rs, metadata, ",", DEFAULT_NAMESPACE);
+    Acl acl = DatabaseAdaptor.buildAcl(rs, ",", DEFAULT_NAMESPACE);
     assertEquals(golden, acl);
   }
 
@@ -262,8 +259,7 @@ public class DatabaseAdaptorTest {
             new GroupPrincipal("dgroup1")))
         .build();
     ResultSet rs = executeQuery("select * from acl");
-    ResultSetMetaData metadata = rs.getMetaData();
-    Acl acl = DatabaseAdaptor.buildAcl(rs, metadata, ",", DEFAULT_NAMESPACE);
+    Acl acl = DatabaseAdaptor.buildAcl(rs, ",", DEFAULT_NAMESPACE);
     assertEquals(golden, acl);
   }
 
@@ -312,8 +308,7 @@ public class DatabaseAdaptorTest {
             new GroupPrincipal("dgroup2")))
         .build();
     ResultSet rs = executeQuery("select * from acl");
-    ResultSetMetaData metadata = rs.getMetaData();
-    Acl acl = DatabaseAdaptor.buildAcl(rs, metadata, ",", DEFAULT_NAMESPACE);
+    Acl acl = DatabaseAdaptor.buildAcl(rs, ",", DEFAULT_NAMESPACE);
     assertEquals(golden, acl);
   }
   
@@ -354,8 +349,7 @@ public class DatabaseAdaptorTest {
             new GroupPrincipal("dgroup2")))
         .build();
     ResultSet rs = executeQuery("select * from acl");
-    ResultSetMetaData metadata = rs.getMetaData();
-    Acl acl = DatabaseAdaptor.buildAcl(rs, metadata, ",", DEFAULT_NAMESPACE);
+    Acl acl = DatabaseAdaptor.buildAcl(rs, ",", DEFAULT_NAMESPACE);
     assertEquals(golden, acl);
   }
   
@@ -383,8 +377,7 @@ public class DatabaseAdaptorTest {
             new GroupPrincipal("dgroup1")))
         .build();
     ResultSet rs = executeQuery("select * from acl");
-    ResultSetMetaData metadata = rs.getMetaData();
-    Acl acl = DatabaseAdaptor.buildAcl(rs, metadata, ",", DEFAULT_NAMESPACE);
+    Acl acl = DatabaseAdaptor.buildAcl(rs, ",", DEFAULT_NAMESPACE);
     assertEquals(golden, acl);
   }
   
@@ -402,7 +395,6 @@ public class DatabaseAdaptorTest {
     List<GroupPrincipal> goldenGroups = Arrays.asList(
         new GroupPrincipal("dgroup1, dgroup2"));
     ResultSet rs = executeQueryAndNext("select * from acl");
-    ResultSetMetaData metadata = rs.getMetaData();
     ArrayList<UserPrincipal> users =
         DatabaseAdaptor.getUserPrincipalsFromResultSet(rs,
             GsaSpecialColumns.GSA_DENY_USERS, "", DEFAULT_NAMESPACE);
@@ -429,7 +421,6 @@ public class DatabaseAdaptorTest {
         new GroupPrincipal("dgroup1"),
         new GroupPrincipal("dgroup2"));
     ResultSet rs = executeQueryAndNext("select * from acl");
-    ResultSetMetaData metadata = rs.getMetaData();
     ArrayList<UserPrincipal> users =
         DatabaseAdaptor.getUserPrincipalsFromResultSet(rs,
             GsaSpecialColumns.GSA_DENY_USERS, " ; ", DEFAULT_NAMESPACE);


### PR DESCRIPTION
This was a leftover from testing with the proxies rather than H2. If
ResultSet is mocked, it can easily return a mocked ResultSetMetaData.

Other changes:
* Remove unused ResultSetMetaData instances.
* Fix lint error.