### PR TITLE
Verify all column names in init, if possible (b/29425538).

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -234,9 +234,11 @@ public class DatabaseAdaptor extends AbstractAdaptor {
             + " be ignored in {0} mode: {1}",
             new Object[] { modeStr, ignored });
       }
-    } else if (singleDocContentSql.isEmpty()) {
-      throw new InvalidConfigurationException(
-          "db.singleDocContentSql cannot be an empty string");
+    // TODO(jlacey): Re-enable this once tests are fixed not to
+    // suppress the column name validation.
+    // } else if (singleDocContentSql.isEmpty()) {
+    //   throw new InvalidConfigurationException(
+    //       "db.singleDocContentSql cannot be an empty string");
     }
 
     respGenerator = loadResponseGenerator(cfg);
@@ -356,6 +358,7 @@ public class DatabaseAdaptor extends AbstractAdaptor {
             + sqlConfig + ": " + sql);
       }
     } catch (SQLException e) {
+      // TODO(jlacey): Throw if this is a SQL syntax error (SQL state 42xxx).
       log.log(Level.WARNING,
           "Unable to validate configured column names for query {0}: {1}",
           new Object[] { sqlConfig, e });

--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -245,6 +245,10 @@ public class DatabaseAdaptor extends AbstractAdaptor {
           "db.singleDocContentSqlParameters", uniqueKey.getContentSqlColumns());
       verifyColumnNames(conn, "db.aclSql", aclSql,
           "db.aclSqlParameters", uniqueKey.getAclSqlColumns());
+      if (!actionColumn.isEmpty()) {
+        verifyColumnNames(conn, "db.everyDocIdSql", everyDocIdSql,
+            "db.actionColumn", Arrays.asList(actionColumn));
+      }
       if (metadataColumns != null) {
         if ("urlAndMetadataLister".equals(modeOfOperation)) {
           verifyColumnNames(conn, "db.everyDocIdSql", everyDocIdSql,

--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -56,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -227,6 +228,97 @@ public class DatabaseAdaptor extends AbstractAdaptor {
   
     aclNamespace = cfg.getValue("adaptor.namespace");
     log.config("namespace: " + aclNamespace);
+
+    // Verify all column names.
+    try (Connection conn = makeNewConnection()) {
+      verifyColumnNames(conn, "db.everyDocIdSql", everyDocIdSql,
+          "db.uniqueKey", uniqueKey.getDocIdSqlColumns());
+      verifyColumnNames(conn, "db.singleDocContentSql", singleDocContentSql,
+          "db.singleDocContentSqlParameters", uniqueKey.getContentSqlColumns());
+      verifyColumnNames(conn, "db.aclSql", aclSql,
+          "db.aclSqlParameters", uniqueKey.getAclSqlColumns());
+      if (metadataColumns != null) {
+        if ("urlAndMetadataLister".equals(modeOfOperation)) {
+          verifyColumnNames(conn, "db.everyDocIdSql", everyDocIdSql,
+              "db.metadataColumns", metadataColumns.keySet());
+        } else {
+          verifyColumnNames(conn, "db.singleDocContentSql", singleDocContentSql,
+              "db.metadataColumns", metadataColumns.keySet());
+        }
+      }
+      if (respGenerator instanceof ResponseGenerator.SingleColumnContent) {
+        ResponseGenerator.SingleColumnContent content =
+            (ResponseGenerator.SingleColumnContent) respGenerator;
+        verifyColumnNames(conn, "db.singleDocContentSql", singleDocContentSql,
+            "db.modeOfOperation." + modeOfOperation + ".columnName",
+            Arrays.asList(content.getContentColumnName()));
+      }
+    } catch (SQLException e) {
+      log.log(Level.WARNING, "Unable to validate configured column names");
+    }
+  }
+
+  /**
+   * Verifies that the given column names exist in the query
+   * ResultSet. The check is case-insensitive, so in some cases the
+   * column names may fail at runtime.
+   *
+   * <p>Database errors are not fatal, this is a best effort only.
+   * This method logs any SQLExceptions that are thrown, but does not
+   * throw them.
+   *
+   * @param sqlConfig the configuration property for the SQL query
+   * @param sql the SQL query; the query is prepared, but not executed
+   * @param columnConfig the configuration property for the column names
+   * @param columnNames the column names to verify
+   * @throws InvalidConfigurationException if any of the columns are not found
+   */
+  @VisibleForTesting
+  static void verifyColumnNames(Connection conn, String sqlConfig, String sql,
+      String columnConfig, Collection<String> columnNames) {
+    if (isNullOrEmptyString(sql)) {
+      log.log(Level.FINEST,
+          "Skipping validation of empty query {0}", sqlConfig);
+      return;
+    }
+    if (columnNames.isEmpty()) {
+      return;
+    }
+    log.log(Level.FINEST, "Looking for columns {0} in {1}",
+        new Object[] { columnNames, sqlConfig });
+
+    // Create a map from case-insensitive names to the originals.
+    TreeMap<String, String> targets =
+        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    for (String name : columnNames) {
+      targets.put(name, name);
+    }
+
+    try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+      ResultSetMetaData rsmd = stmt.getMetaData();
+      if (rsmd == null) {
+        throw new SQLException("ResultSetMetaData is not available");
+      }
+      for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+        String actual = rsmd.getColumnLabel(i);
+        String match = targets.get(actual);
+        if (match != null) {
+          log.log(Level.FINEST,
+              "Matched column \"{0}\" as \"{1}\" in query {2}",
+              new Object[] { match, actual, sqlConfig });
+          targets.remove(match);
+        }
+      }
+      if (!targets.isEmpty()) {
+        throw new InvalidConfigurationException("These columns from "
+            + columnConfig + " " + targets.keySet() + " not found in query "
+            + sqlConfig + ": " + sql);
+      }
+    } catch (SQLException e) {
+      log.log(Level.WARNING,
+          "Unable to validate configured column names for query {0}: {1}",
+          new Object[] { sqlConfig, e });
+    }
   }
 
   /** Get all doc ids from database. */

--- a/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
+++ b/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
@@ -269,7 +269,7 @@ public abstract class ResponseGenerator {
     }
   }
 
-  private abstract static class SingleColumnContent extends ResponseGenerator {
+  abstract static class SingleColumnContent extends ResponseGenerator {
     private final String col;
     private final String contentTypeOverride; // can be null
     private final String contentTypeCol; // can be null

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -136,6 +136,18 @@ class UniqueKey {
     return Collections.unmodifiableList(tmpContentCols);
   }
 
+  List<String> getDocIdSqlColumns() {
+    return names;
+  }
+
+  List<String> getContentSqlColumns() {
+    return contentSqlCols;
+  }
+
+  List<String> getAclSqlColumns() {
+    return aclSqlCols;
+  }
+
   @VisibleForTesting
   UniqueKey(String ukDecls) {
     this(ukDecls, "", "");

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -806,9 +806,6 @@ public class DatabaseAdaptorTest {
     executeUpdate("insert into data(ID, NAME) values('1001', 'John')");
 
     Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.user", "sa");
-    configEntries.put("db.password", "");
-    configEntries.put("db.url", JdbcFixture.URL);
     configEntries.put("db.uniqueKey", "ID:int");
     configEntries.put("db.everyDocIdSql", "select * from data");
     configEntries.put("db.singleDocContentSql", "");
@@ -841,9 +838,6 @@ public class DatabaseAdaptorTest {
     executeUpdate("insert into data(ID, NAME) values('1001', 'John')");
 
     Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.user", "sa");
-    configEntries.put("db.password", "");
-    configEntries.put("db.url", JdbcFixture.URL);
     configEntries.put("db.uniqueKey", "ID:int");
     configEntries.put("db.everyDocIdSql", "");
     configEntries.put("db.singleDocContentSql",

--- a/test/com/google/enterprise/adaptor/database/JdbcFixture.java
+++ b/test/com/google/enterprise/adaptor/database/JdbcFixture.java
@@ -26,8 +26,12 @@ import java.util.ArrayDeque;
 
 /** Manages an in-memory H2 database for test purposes. */
 class JdbcFixture {
+  public static final String DRIVER_CLASS = "org.h2.Driver";
   public static final String URL =
       "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_ESCAPE=";
+  public static final String USER = "sa";
+  public static final String PASSWORD = "";
+
   private static ArrayDeque<AutoCloseable> openObjects = new ArrayDeque<>();
 
   /**
@@ -47,8 +51,8 @@ class JdbcFixture {
     try {
       JdbcDataSource ds = new JdbcDataSource();
       ds.setURL(URL);
-      ds.setUser("sa");
-      ds.setPassword("");
+      ds.setUser(USER);
+      ds.setPassword(PASSWORD);
       return ds.getConnection();
     } catch (SQLException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
This is a best effort, and SQLExceptions are not fatal. Even verified
column names might fail at runtime in certain circumstances.

Related changes:
* Suppress verification in many of the tests. We could revisit this
  after fixing the test configs. but the required config may obscure
  the actual point of these tests.

Other changes:
* Remove db.modeOfOperation.urlAndMetadataLister.columnName config.