### PR TITLE
UniqueKey can be case insensitive looking up column names and types.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Logger;
 
@@ -129,23 +130,24 @@ class UniqueKey {
     if ("".equals(contentSqlColumns.trim())) {
       contentSqlCols = names;
     } else {
-      contentSqlCols = splitIntoNameList(contentSqlColumns);
+      contentSqlCols = splitIntoNameList(contentSqlColumns, tmpTypes.keySet());
     }
 
     if ("".equals(aclSqlColumns.trim())) {
       aclSqlCols = names;
     } else {
-      aclSqlCols = splitIntoNameList(aclSqlColumns);
+      aclSqlCols = splitIntoNameList(aclSqlColumns, tmpTypes.keySet());
     }
   }
 
-  private List<String> splitIntoNameList(String cols) {
+  private static List<String> splitIntoNameList(String cols,
+      Set<String> validNames) {
     List<String> tmpContentCols = new ArrayList<String>();
     for (String name : cols.split(",", 0)) {
       name = name.trim();
-      if (!types.containsKey(name)) {
+      if (!validNames.contains(name)) {
         String errmsg = "Unknown column name: '" + name + "'. Valid names are "
-            + names;
+            + validNames;
         throw new InvalidConfigurationException(errmsg);
       }
       tmpContentCols.add(name);

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -99,7 +99,7 @@ class UniqueKey {
       } else if (tmpTypes.containsKey(name) && tmpTypes.get(name) != type) {
         // The ukDecls contain two keys that differ only in case but are of
         // different types. Force a case-sensitive type lookup by replacing
-        // the case-insensitive type map with a case-sensitive one.
+        // the partial case-insensitive type map with a case-sensitive copy.
         Map<String, ColumnType> caseSensitiveTypes = new TreeMap<>();
         for (String nombre : tmpNames) {
           caseSensitiveTypes.put(nombre, tmpTypes.get(nombre));

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -104,6 +104,32 @@ public class UniqueKeyTest {
   }
 
   @Test
+  public void testCaseSensitiveNameRepeatsAllowed() {
+    UniqueKey uk = new UniqueKey("num:int,Num:string");
+    assertEquals(2, uk.numElementsForTest());
+    assertEquals("num", uk.nameForTest(0));
+    assertEquals("Num", uk.nameForTest(1));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest(0));
+    assertEquals(UniqueKey.ColumnType.STRING, uk.typeForTest(1));
+  }
+
+  @Test
+  public void testCaseInsensitiveNameNotAllowedIfCaseSensitiveKeys() {
+    thrown.expect(InvalidConfigurationException.class);
+    UniqueKey uk = new UniqueKey("id:int,Id:string", "ID", "ID");
+  }
+
+  @Test
+  public void testCaseInsensitiveNameAllowedIfNotCaseSensitiveKeys() {
+    UniqueKey uk = new UniqueKey("id:int", "Id", "ID");
+    assertEquals(1, uk.numElementsForTest());
+    assertEquals("id", uk.nameForTest(0));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest(0));
+    assertEquals(UniqueKey.ColumnType.INT, uk.getType("Id"));
+    assertEquals(UniqueKey.ColumnType.INT, uk.getType("ID"));
+  }
+
+  @Test
   public void testBadDef() {
     thrown.expect(InvalidConfigurationException.class);
     UniqueKey uk = new UniqueKey("numnum:int,strstr/string");

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -131,13 +131,16 @@ public class UniqueKeyTest {
     // If we have multiple column names that differ in both case and type,
     // assume we have a database that supports case-sensitive column names
     // and force the parameter column names to exactly match one of them.
-    UniqueKey uk = newUniqueKey("num:int,Num:string");
-    assertEquals(2, uk.numElementsForTest());
+    UniqueKey uk = newUniqueKey("num:int,nuM:int,Num:string");
+    assertEquals(3, uk.numElementsForTest());
     assertEquals("num", uk.nameForTest(0));
-    assertEquals("Num", uk.nameForTest(1));
+    assertEquals("nuM", uk.nameForTest(1));
+    assertEquals("Num", uk.nameForTest(2));
     assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest(0));
-    assertEquals(UniqueKey.ColumnType.STRING, uk.typeForTest(1));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest(1));
+    assertEquals(UniqueKey.ColumnType.STRING, uk.typeForTest(2));
     assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest("num"));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest("nuM"));
     assertEquals(UniqueKey.ColumnType.STRING, uk.typeForTest("Num"));
     assertEquals(null, uk.typeForTest("NUM"));
   }

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -128,28 +128,40 @@ public class UniqueKeyTest {
 
   @Test
   public void testCaseSensitiveNameRepeatsAllowed() {
+    // If we have multiple column names that differ in both case and type,
+    // assume we have a database that supports case-sensitive column names
+    // and force the parameter column names to exactly match one of them.
     UniqueKey uk = newUniqueKey("num:int,Num:string");
     assertEquals(2, uk.numElementsForTest());
     assertEquals("num", uk.nameForTest(0));
     assertEquals("Num", uk.nameForTest(1));
     assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest(0));
     assertEquals(UniqueKey.ColumnType.STRING, uk.typeForTest(1));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest("num"));
+    assertEquals(UniqueKey.ColumnType.STRING, uk.typeForTest("Num"));
+    assertEquals(null, uk.typeForTest("NUM"));
   }
 
   @Test
   public void testCaseInsensitiveNameNotAllowedIfCaseSensitiveKeys() {
+    // If we have multiple column names that differ in both case and type,
+    // assume we have a database that supports case-sensitive column names
+    // and force the parameter column names to exactly match one of them.
     thrown.expect(InvalidConfigurationException.class);
     UniqueKey uk = newUniqueKey("id:int,Id:string", "ID", "ID");
   }
 
   @Test
   public void testCaseInsensitiveNameAllowedIfNotCaseSensitiveKeys() {
+    // If there are no case variants in the unique key columns, we can be
+    // more lenient in looking up the associated types case-insensitively.
     UniqueKey uk = newUniqueKey("id:int", "Id", "ID");
     assertEquals(1, uk.numElementsForTest());
     assertEquals("id", uk.nameForTest(0));
     assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest(0));
-    assertEquals(UniqueKey.ColumnType.INT, uk.getType("Id"));
-    assertEquals(UniqueKey.ColumnType.INT, uk.getType("ID"));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest("id"));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest("Id"));
+    assertEquals(UniqueKey.ColumnType.INT, uk.typeForTest("ID"));
   }
 
   @Test


### PR DESCRIPTION
This change allows the contentSqlColumns and aclSqlColumns column names
to match any of the ukDecls case insensitively, IFF all the ukDecls can
be uniquely lowercased.