### PR TITLE
Improve init validation when docId.isUrl=true (b/62156745)

### DIFF
--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -49,7 +49,8 @@ class UniqueKey {
   private final List<String> contentSqlCols;  // columns for content query
   private final List<String> aclSqlCols;  // columns for acl query
 
-  UniqueKey(String ukDecls, String contentSqlColumns, String aclSqlColumns) {
+  UniqueKey(String ukDecls, String contentSqlColumns, String aclSqlColumns,
+      boolean encode) {
     if (null == ukDecls) {
       throw new NullPointerException();
     }
@@ -106,6 +107,12 @@ class UniqueKey {
       tmpNames.add(name);
       tmpTypes.put(name, type);
     }
+    if (!encode
+        && (tmpTypes.size() != 1
+            || tmpTypes.values().iterator().next() != ColumnType.STRING)) {
+      throw new InvalidConfigurationException("Invalid db.uniqueKey value:"
+          + " The key must be a single string column when docId.isUrl=true.");
+    }
     names = Collections.unmodifiableList(tmpNames);
     types = Collections.unmodifiableMap(tmpTypes);
 
@@ -136,9 +143,16 @@ class UniqueKey {
     return Collections.unmodifiableList(tmpContentCols);
   }
 
+  // TODO(jlacey): Move these to the tests or change the tests to use
+  // the actual constructor.
   @VisibleForTesting
   UniqueKey(String ukDecls) {
     this(ukDecls, "", "");
+  }
+
+  @VisibleForTesting
+  UniqueKey(String ukDecls, String contentSqlColumns, String aclSqlColumns) {
+    this(ukDecls, contentSqlColumns, aclSqlColumns, true);
   }
 
   String makeUniqueId(ResultSet rs, boolean encode) throws SQLException {

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -98,6 +98,20 @@ public class UniqueKeyTest {
   }
 
   @Test
+  public void testUrlIntColumn() {
+    thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("db.uniqueKey value: The key must be a single");
+    new UniqueKey("numnum:int", "", "", false);
+  }
+
+  @Test
+  public void testUrlTwoColumns() {
+    thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("db.uniqueKey value: The key must be a single");
+    UniqueKey uk = new UniqueKey("str1:string,str2:string", "", "", false);
+  }
+
+  @Test
   public void testNameRepeatsNotAllowed() {
     thrown.expect(InvalidConfigurationException.class);
     UniqueKey uk = new UniqueKey("num:int,num:string");


### PR DESCRIPTION
* Make db.singleDocContentSql optional
* Require db.uniqueKey to be a single string column
* Log a warning about ignored properties