### PR TITLE
Restore the check for empty db.singleDocContentSql.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -235,11 +235,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
             + " be ignored in {0} mode: {1}",
             new Object[] { modeStr, ignored });
       }
-    // TODO(jlacey): Re-enable this once tests are fixed not to
-    // suppress the column name validation.
-    // } else if (singleDocContentSql.isEmpty()) {
-    //   throw new InvalidConfigurationException(
-    //       "db.singleDocContentSql cannot be an empty string");
+    } else if (singleDocContentSql.isEmpty()) {
+      throw new InvalidConfigurationException(
+          "db.singleDocContentSql cannot be an empty string");
     }
 
     respGenerator = loadResponseGenerator(cfg);


### PR DESCRIPTION
This check was added in commit 53d7f39 when db.singleDocContentSql was
made optional to support lister-only mode. It was disabled in commit
a9c9cf4, when verifyColumnNames broke about a dozen tests. Restoration
is brought to you by the improved config from commit 13e0b6b.