### PR TITLE
Improve the error message for empty column names.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -333,6 +333,10 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     TreeMap<String, String> targets =
         new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     for (String name : columnNames) {
+      if (name.isEmpty()) {
+        throw new InvalidConfigurationException("One or more column names from "
+            + columnConfig + " are empty: " + columnNames);
+      }
       targets.put(name, name);
     }
 


### PR DESCRIPTION
Old: These columns from db.metadataColumns [] not found in query ...
New: One or more column names from db.metadataColumns are empty: []