### PR TITLE
Make DatabaseAdaptor.metadataColumns private.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -86,8 +86,7 @@ public class DatabaseAdaptor extends AbstractAdaptor {
   private String everyDocIdSql;
   private String singleDocContentSql;
   private String actionColumn;
-  @VisibleForTesting
-  MetadataColumns metadataColumns;
+  private MetadataColumns metadataColumns;
   private ResponseGenerator respGenerator;
   private String aclSql;
   private String aclPrincipalDelimiter;


### PR DESCRIPTION
Test the config strictly through the produced Metadata objects.