### PR TITLE
Improve UniqueKey error message for unknown column

### DIFF
--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -121,24 +121,26 @@ class UniqueKey {
     if ("".equals(contentSqlColumns.trim())) {
       contentSqlCols = names;
     } else {
-      contentSqlCols = splitIntoNameList(contentSqlColumns, tmpTypes.keySet());
+      contentSqlCols = splitIntoNameList("db.singleDocContentSql",
+          contentSqlColumns, tmpTypes.keySet());
     }
 
     if ("".equals(aclSqlColumns.trim())) {
       aclSqlCols = names;
     } else {
-      aclSqlCols = splitIntoNameList(aclSqlColumns, tmpTypes.keySet());
+      aclSqlCols = splitIntoNameList("db.aclSql", aclSqlColumns,
+          tmpTypes.keySet());
     }
   }
 
-  private static List<String> splitIntoNameList(String cols,
+  private static List<String> splitIntoNameList(String sqlConfig, String cols,
       Set<String> validNames) {
     List<String> tmpContentCols = new ArrayList<String>();
     for (String name : cols.split(",", 0)) {
       name = name.trim();
       if (!validNames.contains(name)) {
-        String errmsg = "Unknown column name: '" + name + "'. Valid names are "
-            + validNames;
+        String errmsg = "Invalid " + sqlConfig + " value: unknown column name "
+            + "'" + name + "'. Valid names are " + validNames;
         throw new InvalidConfigurationException(errmsg);
       }
       tmpContentCols.add(name);

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -133,14 +133,14 @@ class UniqueKey {
     }
   }
 
-  private static List<String> splitIntoNameList(String sqlConfig, String cols,
+  private static List<String> splitIntoNameList(String paramConfig, String cols,
       Set<String> validNames) {
     List<String> tmpContentCols = new ArrayList<String>();
     for (String name : cols.split(",", 0)) {
       name = name.trim();
       if (!validNames.contains(name)) {
-        String errmsg = "Invalid " + sqlConfig + " value: unknown column name "
-            + "'" + name + "'. Valid names are " + validNames;
+        String errmsg = "Unknown column '" + name + "' from "+ paramConfig
+            + " not found in db.uniqueKey: " + validNames;
         throw new InvalidConfigurationException(errmsg);
       }
       tmpContentCols.add(name);

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -83,6 +83,8 @@ public class UniqueKeyTest {
   @Test
   public void testEmptyThrows() {
     thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage(
+        "Invalid db.uniqueKey parameter: value cannot be empty.");
     UniqueKey uk = newUniqueKey(" ");
   }
 
@@ -123,6 +125,8 @@ public class UniqueKeyTest {
   @Test
   public void testNameRepeatsNotAllowed() {
     thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage(
+        "Invalid db.uniqueKey configuration: key name 'num' was repeated.");
     UniqueKey uk = newUniqueKey("num:int,num:string");
   }
 
@@ -151,6 +155,7 @@ public class UniqueKeyTest {
     // assume we have a database that supports case-sensitive column names
     // and force the parameter column names to exactly match one of them.
     thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("unknown column name 'ID'");
     UniqueKey uk = newUniqueKey("id:int,Id:string", "ID", "ID");
   }
 
@@ -170,12 +175,15 @@ public class UniqueKeyTest {
   @Test
   public void testBadDef() {
     thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("Invalid UniqueKey definition for 'strstr/string'.");
     UniqueKey uk = newUniqueKey("numnum:int,strstr/string");
   }
 
   @Test
   public void testUnknownContentCol() {
     thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("Invalid db.singleDocContentSql value: "
+        + "unknown column name 'IsStranger'.");
     UniqueKey uk = newUniqueKey("numnum:int,strstr:string",
         "numnum,IsStranger,strstr", "");
   }
@@ -183,6 +191,8 @@ public class UniqueKeyTest {
   @Test
   public void testUnknownAclCol() {
     thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("Invalid db.aclSql value: "
+        + "unknown column name 'IsStranger'.");
     UniqueKey uk = newUniqueKey("numnum:int,strstr:string", "",
         "numnum,IsStranger,strstr");
   }

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -155,7 +155,7 @@ public class UniqueKeyTest {
     // assume we have a database that supports case-sensitive column names
     // and force the parameter column names to exactly match one of them.
     thrown.expect(InvalidConfigurationException.class);
-    thrown.expectMessage("unknown column name 'ID'");
+    thrown.expectMessage("Unknown column 'ID'");
     UniqueKey uk = newUniqueKey("id:int,Id:string", "ID", "ID");
   }
 
@@ -182,8 +182,8 @@ public class UniqueKeyTest {
   @Test
   public void testUnknownContentCol() {
     thrown.expect(InvalidConfigurationException.class);
-    thrown.expectMessage("Invalid db.singleDocContentSql value: "
-        + "unknown column name 'IsStranger'.");
+    thrown.expectMessage(
+        "Unknown column 'IsStranger' from db.singleDocContentSql");
     UniqueKey uk = newUniqueKey("numnum:int,strstr:string",
         "numnum,IsStranger,strstr", "");
   }
@@ -191,8 +191,7 @@ public class UniqueKeyTest {
   @Test
   public void testUnknownAclCol() {
     thrown.expect(InvalidConfigurationException.class);
-    thrown.expectMessage("Invalid db.aclSql value: "
-        + "unknown column name 'IsStranger'.");
+    thrown.expectMessage("Unknown column 'IsStranger' from db.aclSql");
     UniqueKey uk = newUniqueKey("numnum:int,strstr:string", "",
         "numnum,IsStranger,strstr");
   }


### PR DESCRIPTION
Also, since we have more extensive validation, make the UniqueKeyTests
expect specific error messages on thrown IllegalConfigurationExceptions.