### PR TITLE
Improve code coverage for ValidatedUri.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/ValidatedUri.java
+++ b/src/com/google/enterprise/adaptor/database/ValidatedUri.java
@@ -42,7 +42,7 @@ class ValidatedUri {
     }
     try {
       // Basic syntax checking, with more understandable error messages.
-      // Also ensures the URI is a URL, not a URN.
+      // Also ensures the URI is a URL, not a URN, and is absolute.
       new URL(uriString);
       // Advanced syntax checking, with more cryptic error messages.
       uri = new URI(uriString);

--- a/src/com/google/enterprise/adaptor/database/ValidatedUri.java
+++ b/src/com/google/enterprise/adaptor/database/ValidatedUri.java
@@ -54,10 +54,6 @@ class ValidatedUri {
       throw new URISyntaxException(uriString, reason);
     }
 
-    if (!uri.isAbsolute()) {
-      throw new URISyntaxException(uriString, "relative URIs are not allowed");
-    }
-
     if (Strings.isNullOrEmpty(uri.getHost())) {
       throw new URISyntaxException(uriString, "no host");
     }

--- a/test/com/google/enterprise/adaptor/database/ValidatedUriTest.java
+++ b/test/com/google/enterprise/adaptor/database/ValidatedUriTest.java
@@ -77,7 +77,14 @@ public class ValidatedUriTest {
   public void testNoHost() throws Exception {
     thrown.expect(URISyntaxException.class);
     thrown.expectMessage("no host");
-    new ValidatedUri("http:/foo/bar");
+    new ValidatedUri("http:///foo/bar");
+  }
+
+  @Test
+  public void testNoAuthority() throws Exception {
+    thrown.expect(URISyntaxException.class);
+    thrown.expectMessage("no host");
+    new ValidatedUri("file:/foo/bar");
   }
 
   @Test

--- a/test/com/google/enterprise/adaptor/database/ValidatedUriTest.java
+++ b/test/com/google/enterprise/adaptor/database/ValidatedUriTest.java
@@ -43,7 +43,15 @@ public class ValidatedUriTest {
   @Test
   public void testNoProtocol() throws Exception {
     thrown.expect(URISyntaxException.class);
+    thrown.expectMessage("no protocol");
     new ValidatedUri("//foo/bar");
+  }
+
+  @Test
+  public void testRelativeUri() throws Exception {
+    thrown.expect(URISyntaxException.class);
+    thrown.expectMessage("no protocol");
+    new ValidatedUri("foo/bar");
   }
 
   @Test
@@ -59,15 +67,17 @@ public class ValidatedUriTest {
   }
 
   @Test
-  public void testNoHost() throws Exception {
+  public void testNoHostOrPath() throws Exception {
     thrown.expect(URISyntaxException.class);
+    thrown.expectMessage("Expected authority");
     new ValidatedUri("http://");
   }
 
   @Test
-  public void testRelativeUri() throws Exception {
+  public void testNoHost() throws Exception {
     thrown.expect(URISyntaxException.class);
-    new ValidatedUri("foo/bar");
+    thrown.expectMessage("no host");
+    new ValidatedUri("http:/foo/bar");
   }
 
   @Test


### PR DESCRIPTION
The check of URI.isAbsolute leads to dead code. The URL constructor
with one argument does not allow relative URIs.