### PR TITLE
Improve code coverage for DatabaseAdaptorTest (part 2).

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -565,10 +565,7 @@ public class DatabaseAdaptor extends AbstractAdaptor {
       addMetadataToResponse(resp, rs);
       // Generate Acl if aclSql is provided.
       if (aclSql != null) {
-        Acl acl = getAcl(conn, id.getUniqueId());
-        if (acl != null) {
-          resp.setAcl(acl);
-        }
+        resp.setAcl(getAcl(conn, id.getUniqueId()));
       }
       // Generate response body.
       // In database adaptor's case, we almost never want to follow the URLs.

--- a/test/com/google/enterprise/adaptor/TestHelper.java
+++ b/test/com/google/enterprise/adaptor/TestHelper.java
@@ -41,28 +41,52 @@ public class TestHelper {
     }
   };
 
-  public static AdaptorContext createConfigAdaptorContext(final Config config) {
-    return new WrapperAdaptor.WrapperAdaptorContext(null) {
-      @Override
-      public Config getConfig() {
-        return config;
-      }
+  public static RecordingContext createConfigAdaptorContext(Config config) {
+    return new RecordingContext(config);
+  }
 
-      @Override
-      public void setPollingIncrementalLister(PollingIncrementalLister lister) {
-        // do nothing
-      }
+  /**
+   * A fake implementation of AdaptorContext that simply returns the
+   * values its given, and records the values it receives.
+   */
+  public static class RecordingContext
+      extends WrapperAdaptor.WrapperAdaptorContext {
+    private final Config config;
+    private PollingIncrementalLister lister;
+    private AuthzAuthority authzAuthority;
 
-      @Override
-      public SensitiveValueDecoder getSensitiveValueDecoder() {
-        return SENSITIVE_VALUE_DECODER;
-      }
+    private RecordingContext(Config config) {
+      super(null);
+      this.config = config;
+    }
 
-      @Override
-      public void setAuthzAuthority(AuthzAuthority authzAuthority) {
-        // do nothing
-      }
-    };
+    @Override
+    public Config getConfig() {
+      return config;
+    }
+
+    @Override
+    public void setPollingIncrementalLister(PollingIncrementalLister lister) {
+      this.lister = lister;
+    }
+
+    @Override
+    public SensitiveValueDecoder getSensitiveValueDecoder() {
+      return SENSITIVE_VALUE_DECODER;
+    }
+
+    @Override
+    public void setAuthzAuthority(AuthzAuthority authzAuthority) {
+      this.authzAuthority = authzAuthority;
+    }
+
+    public PollingIncrementalLister getPollingIncrementalLister() {
+      return lister;
+    }
+
+    public AuthzAuthority getAuthzAuthority() {
+      return authzAuthority;
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Part 2: ACLs and authZ.
Improves coverage of DatabaseAdaptor from 69% to 78%.

Production changes:
* Eliminate a doubly-redundant null check on getAcl, which
  doesn't return null. Also, Response.setAcl accepts null.

Extend the mock AdaptorContext in TestHelper to a recording fake.
Extend getObjectUnderTest to optionally capture the AdaptorContext.