### PR TITLE
Add a Builder for UniqueKey

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -172,10 +172,6 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     password = context.getSensitiveValueDecoder().decodeValue(
         cfg.getValue("db.password"));
 
-    boolean leaveIdAlone = new Boolean(cfg.getValue("docId.isUrl"));
-    encodeDocId = !leaveIdAlone;
-    log.config("encodeDocId: " + encodeDocId);
-
     everyDocIdSql = cfg.getValue("db.everyDocIdSql");
     log.config("every doc id sql: " + everyDocIdSql);
 
@@ -203,6 +199,12 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     }
 
     modeOfOperation = cfg.getValue("db.modeOfOperation");
+    log.config("mode of operation: " + modeOfOperation);
+
+    boolean leaveIdAlone = new Boolean(cfg.getValue("docId.isUrl"));
+    encodeDocId = !leaveIdAlone;
+    log.config("encodeDocId: " + encodeDocId);
+
     if (modeOfOperation.equals("urlAndMetadataLister") && encodeDocId) {
       String errmsg = "db.modeOfOperation of \"" + modeOfOperation
           + "\" requires docId.isUrl to be \"true\"";
@@ -405,7 +407,7 @@ public class DatabaseAdaptor extends AbstractAdaptor {
         BufferedPusher outstream = new BufferedPusher(pusher)) {
       log.finer("queried for stream");
       while (rs.next()) {
-        DocId id = new DocId(uniqueKey.makeUniqueId(rs, encodeDocId));
+        DocId id = new DocId(uniqueKey.makeUniqueId(rs));
         DocIdPusher.Record.Builder builder = new DocIdPusher.Record.Builder(id);
         if (isDeleteAction(rs)) {
           builder.setDeleteFromIndex(true);
@@ -916,7 +918,7 @@ public class DatabaseAdaptor extends AbstractAdaptor {
             hasColumn(rs.getMetaData(), GsaSpecialColumns.GSA_TIMESTAMP);
         log.log(Level.FINEST, "hasTimestamp: {0}", hasTimestamp);
         while (rs.next()) {
-          DocId id = new DocId(uniqueKey.makeUniqueId(rs, encodeDocId));
+          DocId id = new DocId(uniqueKey.makeUniqueId(rs));
           DocIdPusher.Record.Builder builder =
               new DocIdPusher.Record.Builder(id).setCrawlImmediately(true);
           if ("urlAndMetadataLister".equals(modeOfOperation)) {

--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -176,14 +176,6 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     encodeDocId = !leaveIdAlone;
     log.config("encodeDocId: " + encodeDocId);
 
-    uniqueKey = new UniqueKey(
-        cfg.getValue("db.uniqueKey"),
-        cfg.getValue("db.singleDocContentSqlParameters"),
-        cfg.getValue("db.aclSqlParameters"),
-        encodeDocId
-    );
-    log.config("primary key: " + uniqueKey);
-
     everyDocIdSql = cfg.getValue("db.everyDocIdSql");
     log.config("every doc id sql: " + everyDocIdSql);
 
@@ -277,18 +269,24 @@ public class DatabaseAdaptor extends AbstractAdaptor {
           "The following properties are set but will be ignored: " + ignored);
     }
 
+    UniqueKey.Builder ukBuilder
+        = new UniqueKey.Builder(cfg.getValue("db.uniqueKey"))
+        .setEncodeDocIds(encodeDocId)
+        .setContentSqlColumns(cfg.getValue("db.singleDocContentSqlParameters"))
+        .setAclSqlColumns(cfg.getValue("db.aclSqlParameters"));
+
     // Verify all column names.
     try (Connection conn = makeNewConnection()) {
       Map<String, Integer> columnTypes =
           verifyColumnNames(conn, "db.everyDocIdSql", everyDocIdSql,
-              "db.uniqueKey", uniqueKey.getDocIdSqlColumns());
-      uniqueKey.addColumnTypes(columnTypes);
+              "db.uniqueKey", ukBuilder.getDocIdSqlColumns());
+      ukBuilder.addColumnTypes(columnTypes);
       verifyColumnNames(conn, "db.updateSql", updateSql,
-          "db.uniqueKey", uniqueKey.getDocIdSqlColumns());
+          "db.uniqueKey", ukBuilder.getDocIdSqlColumns());
       verifyColumnNames(conn, "db.singleDocContentSql", singleDocContentSql,
-          "db.singleDocContentSqlParameters", uniqueKey.getContentSqlColumns());
+          "db.singleDocContentSqlParameters", ukBuilder.getContentSqlColumns());
       verifyColumnNames(conn, "db.aclSql", aclSql,
-          "db.aclSqlParameters", uniqueKey.getAclSqlColumns());
+          "db.aclSqlParameters", ukBuilder.getAclSqlColumns());
       if (!actionColumn.isEmpty()) {
         verifyColumnNames(conn, "db.everyDocIdSql", everyDocIdSql,
             "db.actionColumn", Arrays.asList(actionColumn));
@@ -314,6 +312,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     } catch (SQLException e) {
       log.log(Level.WARNING, "Unable to validate configured column names");
     }
+
+    uniqueKey = ukBuilder.build();
+    log.config("primary key: " + uniqueKey);
   }
 
   /**

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -47,182 +47,29 @@ class UniqueKey {
     LONG
   }
 
-  private final List<String> names;  // columns used for DocId
+  private final List<String> docIdSqlCols;  // columns used for DocId
   private final Map<String, ColumnType> types;  // types of DocId columns
   private final List<String> contentSqlCols;  // columns for content query
   private final List<String> aclSqlCols;  // columns for acl query
 
-  UniqueKey(String ukDecls, String contentSqlColumns, String aclSqlColumns,
-      boolean encode) {
-    if (null == ukDecls) {
-      throw new NullPointerException();
-    }
-    if (null == contentSqlColumns) {
-      throw new NullPointerException();
-    }
-    if (null == aclSqlColumns) {
-      throw new NullPointerException();
-    }
-
-    if ("".equals(ukDecls.trim())) {
-      String errmsg = "Invalid db.uniqueKey parameter: value cannot be empty.";
-      throw new InvalidConfigurationException(errmsg);
-    }
-
-    List<String> tmpNames = new ArrayList<String>();
-    Map<String, ColumnType> tmpTypes =
-        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    for (String e : ukDecls.split(",", 0)) {
-      log.fine("element: `" + e + "'");
-      e = e.trim();
-      String def[] = e.split(":", 2);
-      String name = def[0].trim();
-      ColumnType type;
-      if (def.length == 1) {
-        // No type given. Try to get type from ResultSetMetaData later.
-        type = null;
-      } else {
-        String typeStr = def[1].trim();
-        try {
-          type = ColumnType.valueOf(typeStr.toUpperCase(US));
-        } catch (IllegalArgumentException iae) {
-          String errmsg = "Invalid UniqueKey type '" + typeStr
-              + "' for '" + name + "'. Valid types are: "
-              + Arrays.toString(ColumnType.values()).toLowerCase(US);
-          throw new InvalidConfigurationException(errmsg);
-        }
-      }
-      if (tmpTypes.containsKey(name)) {
-        String errmsg = "Invalid db.uniqueKey configuration: key name '"
-            + name + "' was repeated.";
-        throw new InvalidConfigurationException(errmsg);
-      }
-      tmpNames.add(name);
-      tmpTypes.put(name, type);
-    }
-    if (!encode
-        && (tmpTypes.size() != 1
-            || tmpTypes.values().iterator().next() != ColumnType.STRING)) {
-      throw new InvalidConfigurationException("Invalid db.uniqueKey value:"
-          + " The key must be a single string column when docId.isUrl=true.");
-    }
-    names = Collections.unmodifiableList(tmpNames);
-    types = tmpTypes;
-
-    if ("".equals(contentSqlColumns.trim())) {
-      contentSqlCols = names;
-    } else {
-      contentSqlCols = splitIntoNameList("db.singleDocContentSqlParameters",
-          contentSqlColumns, tmpTypes.keySet());
-    }
-
-    if ("".equals(aclSqlColumns.trim())) {
-      aclSqlCols = names;
-    } else {
-      aclSqlCols = splitIntoNameList("db.aclSqlParameters", aclSqlColumns,
-          tmpTypes.keySet());
-    }
-  }
-
-  private static List<String> splitIntoNameList(String paramConfig, String cols,
-      Set<String> validNames) {
-    List<String> tmpContentCols = new ArrayList<String>();
-    for (String name : cols.split(",", 0)) {
-      name = name.trim();
-      if (!validNames.contains(name)) {
-        String errmsg = "Unknown column '" + name + "' from " + paramConfig
-            + " not found in db.uniqueKey: " + validNames;
-        throw new InvalidConfigurationException(errmsg);
-      }
-      tmpContentCols.add(name);
-    }
-    return Collections.unmodifiableList(tmpContentCols);
-  }
-
-  List<String> getDocIdSqlColumns() {
-    return names;
-  }
-
-  List<String> getContentSqlColumns() {
-    return contentSqlCols;
-  }
-
-  List<String> getAclSqlColumns() {
-    return aclSqlCols;
-  }
-
-  /**
-   * Attempt to extract ColumnTypes from the supplied Map
-   * of column names to java.sql.Type
-   *
-   * @param sqlTypes Map of column names to Integer java.sql.Types
-   */
-  void addColumnTypes(Map<String, Integer> sqlTypes) {
-    for (Map.Entry<String, Integer> entry : sqlTypes.entrySet()) {
-      if (types.get(entry.getKey()) != null) {
-        continue;
-      }
-      ColumnType type;
-      switch (entry.getValue()) {
-        case Types.BIT:
-        case Types.BOOLEAN:
-        case Types.TINYINT:
-        case Types.SMALLINT:
-        case Types.INTEGER:
-          type = ColumnType.INT;
-          break;
-        case Types.BIGINT:
-          type = ColumnType.LONG;
-          break;
-        case Types.CHAR:
-        case Types.VARCHAR:
-        case Types.LONGVARCHAR:
-        case Types.NCHAR:
-        case Types.NVARCHAR:
-        case Types.LONGNVARCHAR:
-        case Types.DATALINK:
-          type = ColumnType.STRING;
-          break;
-        case Types.DATE:
-          type = ColumnType.DATE;
-          break;
-        case Types.TIME:
-          type = ColumnType.TIME;
-          break;
-        case Types.TIMESTAMP:
-          type = ColumnType.TIMESTAMP;
-          break;
-        default:
-          String errmsg = "Invalid UniqueKey SQLtype '" + entry.getValue() + "'"
-              + " for " + entry.getKey() + ". Please set an explicit key type"
-              + " in db.uniqueKey.";
-          throw new InvalidConfigurationException(errmsg);
-      }
-      types.put(entry.getKey(), type);
-    }
-    ArrayList<String> badColumns = new ArrayList<>();
-    for (Map.Entry<String, ColumnType> entry : types.entrySet()) {
-      if (entry.getValue() == null) {
-        badColumns.add(entry.getKey());
-      }
-    }
-    if (!badColumns.isEmpty()) {
-      throw new InvalidConfigurationException("Unknown column type for the"
-          + " following columns: " + badColumns
-          + ". Please set explicit types in db.uniqueKey.");
-    }
+  private UniqueKey(List<String> docIdSqlCols, Map<String, ColumnType> types,
+      List<String> contentSqlCols, List<String> aclSqlCols) {
+    this.docIdSqlCols = docIdSqlCols;
+    this.types = types;
+    this.contentSqlCols = contentSqlCols;
+    this.aclSqlCols = aclSqlCols;
   }
 
   String makeUniqueId(ResultSet rs, boolean encode) throws SQLException {
     if (!encode) {
-      if (names.size() == 1) {
-        return rs.getString(names.get(0));
+      if (docIdSqlCols.size() == 1) {
+        return rs.getString(docIdSqlCols.get(0));
       }
       throw new AssertionError("not encoding implies exactly one parameter");
     }
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < names.size(); i++) {
-      String name = names.get(i);
+    for (int i = 0; i < docIdSqlCols.size(); i++) {
+      String name = docIdSqlCols.get(i);
       String part;
       switch (types.get(name)) {
         case INT:
@@ -257,7 +104,7 @@ class UniqueKey {
     // parse on / that isn't preceded by escape char _
     // (a / that is preceded by _ is part of column value)
     String parts[] = uniqueId.split("(?<!_)/", -1);
-    if (parts.length != names.size()) {
+    if (parts.length != docIdSqlCols.size()) {
       String errmsg = "Wrong number of values for primary key: "
           + "id: " + uniqueId + ", parts: " + Arrays.asList(parts);
       throw new IllegalStateException(errmsg);
@@ -265,7 +112,7 @@ class UniqueKey {
     Map<String, String> zip = new TreeMap<String, String>();
     for (int i = 0; i < parts.length; i++) {
       String columnValue = decodeSlashInData(parts[i]);
-      zip.put(names.get(i), columnValue);
+      zip.put(docIdSqlCols.get(i), columnValue);
     }
     for (int i = 0; i < sqlCols.size(); i++) {
       String colName = sqlCols.get(i);
@@ -352,33 +199,9 @@ class UniqueKey {
     return id;
   }
 
-  /** Number of columns that make up the primary key. */
-  @VisibleForTesting
-  int numElementsForTest() {
-    return names.size(); 
-  }
-
-  /** Name of particular column in primary key. */
-  @VisibleForTesting
-  String nameForTest(int i) {
-    return names.get(i);
-  }
-
-  /** Type of particular column in primary key. */
-  @VisibleForTesting
-  ColumnType typeForTest(int i) {
-    return types.get(names.get(i));
-  }
-
-  /** Type of a named column in primary key. */
-  @VisibleForTesting
-  ColumnType typeForTest(String name) {
-    return types.get(name);
-  }
-
   @Override
   public String toString() {
-    return "UniqueKey(" + names + "," + types + "," + contentSqlCols + ","
+    return "UniqueKey(" + docIdSqlCols + "," + types + "," + contentSqlCols + ","
         + aclSqlCols + ")";
   }
 
@@ -387,7 +210,7 @@ class UniqueKey {
     boolean same = false;
     if (other instanceof UniqueKey) {
       UniqueKey key = (UniqueKey) other;
-      same = names.equals(key.names)
+      same = docIdSqlCols.equals(key.docIdSqlCols)
           && types.equals(key.types)
           && contentSqlCols.equals(key.contentSqlCols)
           && aclSqlCols.equals(key.aclSqlCols);
@@ -397,6 +220,247 @@ class UniqueKey {
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(names, types, contentSqlCols, aclSqlCols);
+    return java.util.Objects.hash(docIdSqlCols, types, contentSqlCols, aclSqlCols);
+  }
+
+  /** Builder to create instances of {@code UniqueKey}. */
+  static class Builder {
+    private List<String> docIdSqlCols;  // columns used for DocId
+    private Map<String, ColumnType> types;  // types of DocId columns
+    private List<String> contentSqlCols;  // columns for content query
+    private List<String> aclSqlCols;  // columns for acl query
+    private boolean encodeDocIds = true;
+
+    /**
+     * Create a mutable builder for the UniqueKey configuration.
+     *
+     * @param docIdSqlColumns comma separated list of column names
+     *     and optional types of the form: columnName[:type][, ...].
+     *     If specified {@code type} must be one of
+     *     {@code int, long, string, date, time, or timestamp}.
+     * @throws InvalidConfigurationException if duplicate column names are
+     *     provided, or an invalid column type is specified.
+     * @throws NullPointerException if docIdSqlColumns is null
+     */
+    Builder(String docIdSqlColumns) throws InvalidConfigurationException {
+      if (null == docIdSqlColumns) {
+        throw new NullPointerException();
+      }
+
+      if ("".equals(docIdSqlColumns.trim())) {
+        throw new InvalidConfigurationException(
+            "Invalid db.uniqueKey parameter: value cannot be empty.");
+      }
+
+      docIdSqlCols = new ArrayList<String>();
+      types = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+      for (String e : docIdSqlColumns.split(",", 0)) {
+        log.fine("element: `" + e + "'");
+        e = e.trim();
+        String def[] = e.split(":", 2);
+        String name = def[0].trim();
+        ColumnType type;
+        if (def.length == 1) {
+          // No type given. Try to get type from ResultSetMetaData later.
+          type = null;
+        } else {
+          String typeStr = def[1].trim();
+          try {
+            type = ColumnType.valueOf(typeStr.toUpperCase(US));
+          } catch (IllegalArgumentException iae) {
+            String errmsg = "Invalid UniqueKey type '" + typeStr
+                + "' for '" + name + "'. Valid types are: "
+                + Arrays.toString(ColumnType.values()).toLowerCase(US);
+            throw new InvalidConfigurationException(errmsg);
+          }
+        }
+        docIdSqlCols.add(name);
+        if (types.put(name, type) != null) {
+          String errmsg = "Invalid db.uniqueKey configuration: key name '"
+              + name + "' was repeated.";
+          throw new InvalidConfigurationException(errmsg);
+        }
+      }
+      docIdSqlCols = Collections.unmodifiableList(docIdSqlCols);
+      contentSqlCols = docIdSqlCols;
+      aclSqlCols = docIdSqlCols;
+    }
+
+    /**
+     * Sets whether to encode DocIds composed of mulitple column values,
+     * separated by slashes.
+     * If not encoding DocIds, the {@code docIdSqlColumns} supplied to the
+     * {@code Builder} must consist of a single column of type {@code string}.
+     *
+     * @param encodeDocIds if {@code true} encode the DocId
+     */
+    Builder setEncodeDocIds(boolean encodeDocIds) {
+      this.encodeDocIds = encodeDocIds;
+      return this;
+    }
+
+    /**
+     * Sets the columns used by the {@code db.singleDocContentSql} query
+     * parameters. The columms must also be included in the
+     * {@code docIdSqlColumns} supplied to the {@code Builder} constructor.
+     *
+     * @param contentSqlColumns comma separated list of column names
+     * @return this Builder
+     * @throws InvalidConfigurationException if a column name is not found in
+     *     the list of columns supplied to this Builder's constructor
+     * @throws NullPointerException if contentSqlColumns is null
+     */
+    Builder setContentSqlColumns(String contentSqlColumns)
+        throws InvalidConfigurationException {
+      if (null == contentSqlColumns) {
+        throw new NullPointerException();
+      }
+      if (!contentSqlColumns.trim().isEmpty()) {
+        this.contentSqlCols
+            = splitIntoNameList("db.singleDocContentSqlParameters",
+                contentSqlColumns, types.keySet());
+      }
+      return this;
+    }
+
+    /**
+     * Sets the columns used by the {@code db.aclSql} query parameters.
+     * The columms must also be included in the
+     * {@code docIdSqlColumns} supplied to the {@code Builder} constructor.
+     *
+     * @param aclSqlColumns comma separated list of column names
+     * @return this Builder
+     * @throws InvalidConfigurationException if a column name is not found in
+     *     the list of columns supplied to this Builder's constructor.
+     * @throws NullPointerException if aclSqlColumns is null
+     */
+    Builder setAclSqlColumns(String aclSqlColumns)
+        throws InvalidConfigurationException {
+      if (null == aclSqlColumns) {
+        throw new NullPointerException();
+      }
+      if (!aclSqlColumns.trim().isEmpty()) {
+        this.aclSqlCols = splitIntoNameList("db.aclSqlParameters",
+            aclSqlColumns, types.keySet());
+      }
+      return this;
+    }
+
+    private static List<String> splitIntoNameList(String paramConfig,
+        String cols, Set<String> validNames) {
+      List<String> columnNames = new ArrayList<String>();
+      for (String name : cols.split(",", 0)) {
+        name = name.trim();
+        if (!validNames.contains(name)) {
+          String errmsg = "Unknown column '" + name + "' from " + paramConfig
+              + " not found in db.uniqueKey: " + validNames;
+          throw new InvalidConfigurationException(errmsg);
+        }
+        columnNames.add(name);
+      }
+      return Collections.unmodifiableList(columnNames);
+    }
+
+    /**
+     * Attempt to extract ColumnTypes from the supplied Map
+     * of column names to java.sql.Type
+     *
+     * @param sqlTypes Map of column names to Integer java.sql.Types
+     * @return this Builder
+     * @throws InvalidConfigurationException if a column's SQL type cannot be
+     *     mapped to a ColumnType.
+     */
+    Builder addColumnTypes(Map<String, Integer> sqlTypes) {
+      for (Map.Entry<String, Integer> entry : sqlTypes.entrySet()) {
+        if (types.get(entry.getKey()) != null) {
+          continue;
+        }
+        ColumnType type;
+        switch (entry.getValue()) {
+          case Types.BIT:
+          case Types.BOOLEAN:
+          case Types.TINYINT:
+          case Types.SMALLINT:
+          case Types.INTEGER:
+            type = ColumnType.INT;
+            break;
+          case Types.BIGINT:
+            type = ColumnType.LONG;
+            break;
+          case Types.CHAR:
+          case Types.VARCHAR:
+          case Types.LONGVARCHAR:
+          case Types.NCHAR:
+          case Types.NVARCHAR:
+          case Types.LONGNVARCHAR:
+          case Types.DATALINK:
+            type = ColumnType.STRING;
+            break;
+          case Types.DATE:
+            type = ColumnType.DATE;
+            break;
+          case Types.TIME:
+            type = ColumnType.TIME;
+            break;
+          case Types.TIMESTAMP:
+            type = ColumnType.TIMESTAMP;
+            break;
+          default:
+            String errmsg = "Invalid UniqueKey SQLtype '" + entry.getValue()
+                + "' for " + entry.getKey() + ". Please set an explicit key "
+                + "type in db.uniqueKey.";
+            throw new InvalidConfigurationException(errmsg);
+        }
+        types.put(entry.getKey(), type);
+      }
+      return this;
+    }
+
+    /** Return the list of docIdSqlColumns. */
+    List<String> getDocIdSqlColumns() {
+      return docIdSqlCols;
+    }
+
+    /** Return the list of contentSqlColumns. */
+    List<String> getContentSqlColumns() {
+      return contentSqlCols;
+    }
+
+    /** Return the list of aclSqlColumns. */
+    List<String> getAclSqlColumns() {
+      return aclSqlCols;
+    }
+
+    /** Return the Map of column types. */
+    @VisibleForTesting
+    Map<String, ColumnType> getColumnTypes() {
+      return types;
+    }
+
+    /**
+     * @return a {@code UniqueKey} instance constructed with configuration
+     *   supplied to this Builder.
+     */
+    UniqueKey build() throws InvalidConfigurationException {
+      ArrayList<String> badColumns = new ArrayList<>();
+      for (Map.Entry<String, ColumnType> entry : types.entrySet()) {
+        if (entry.getValue() == null) {
+          badColumns.add(entry.getKey());
+        }
+      }
+      if (!badColumns.isEmpty()) {
+        throw new InvalidConfigurationException("Unknown column type for the"
+            + " following columns: " + badColumns
+            + ". Please set explicit types in db.uniqueKey.");
+      }
+      types = Collections.unmodifiableMap(types);
+      if (!encodeDocIds
+          && (types.size() != 1
+              || types.values().iterator().next() != ColumnType.STRING)) {
+        throw new InvalidConfigurationException("Invalid db.uniqueKey value:"
+           + " The key must be a single string column when docId.isUrl=true.");
+      }
+      return new UniqueKey(docIdSqlCols, types, contentSqlCols, aclSqlCols);
+    }
   }
 }

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -649,13 +649,16 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitUniqueKeyInvalidType() throws Exception {
+    executeUpdate("create table data(productid int, other varchar)");
     // Type of unique key id value cannot be "notvalid", since it's invalid.
     // That cat be int, string, timestamp, date, time, and long.
     Map<String, String> moreEntries = new HashMap<String, String>();
     moreEntries.put("db.uniqueKey", "productid:notvalid");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.modeOfOperation", "rowToText");
-    moreEntries.put("db.everyDocIdSql", "");
+    moreEntries.put("db.everyDocIdSql", "select productid from data");
+    moreEntries.put("db.singleDocContentSql",
+        "select * from data where productid = ?");
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage("Invalid UniqueKey type 'notvalid'");
     getObjectUnderTest(moreEntries);
@@ -663,12 +666,15 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitUniqueKeyContainsRepeatedKeyName() throws Exception {
+    executeUpdate("create table data(productid int, other varchar)");
     // Value of unique key cannot contain repeated key name.
     Map<String, String> moreEntries = new HashMap<String, String>();
     moreEntries.put("db.uniqueKey", "productid:int,productid:string");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.modeOfOperation", "rowToText");
-    moreEntries.put("db.everyDocIdSql", "");
+    moreEntries.put("db.everyDocIdSql", "select productid from data");
+    moreEntries.put("db.singleDocContentSql",
+        "select * from data where productid = ?");
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage("key name 'productid' was repeated");
     getObjectUnderTest(moreEntries);
@@ -676,13 +682,15 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitUniqueKeyEmpty() throws Exception {
+    executeUpdate("create table data(id int, url varchar)");
     // Value of unique id cannot be empty.
     // The value has to be something like "keyname:type"
     Map<String, String> moreEntries = new HashMap<String, String>();
     moreEntries.put("db.uniqueKey", "");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.modeOfOperation", "urlAndMetadataLister");
-    moreEntries.put("db.everyDocIdSql", "");
+    moreEntries.put("docId.isUrl", "true");
+    moreEntries.put("db.everyDocIdSql", "select id from data");
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage("db.uniqueKey parameter: value cannot be empty");
     getObjectUnderTest(moreEntries);
@@ -690,12 +698,13 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitUniqueKeyUrl() throws Exception {
+    executeUpdate("create table data(id int, url varchar)");
     Map<String, String> moreEntries = new HashMap<String, String>();
     moreEntries.put("db.modeOfOperation", "urlAndMetadataLister");
     moreEntries.put("docId.isUrl", "true");
     moreEntries.put("db.uniqueKey", "id:int, url:string");
     // Required for validation, but not specific to this test.
-    moreEntries.put("db.everyDocIdSql", "");
+    moreEntries.put("db.everyDocIdSql", "select * from data");
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage("db.uniqueKey value: The key must be a single");
     getObjectUnderTest(moreEntries);

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -704,7 +704,7 @@ public class DatabaseAdaptorTest {
     moreEntries.put("docId.isUrl", "true");
     moreEntries.put("db.uniqueKey", "id:int, url:string");
     // Required for validation, but not specific to this test.
-    moreEntries.put("db.everyDocIdSql", "select * from data");
+    moreEntries.put("db.everyDocIdSql", "select id, url from data");
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage("db.uniqueKey value: The key must be a single");
     getObjectUnderTest(moreEntries);
@@ -922,11 +922,13 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitUrlMetadataLister_noDocIdIsUrl() throws Exception {
+    executeUpdate("create table data(id integer, url varchar)");
     Map<String, String> moreEntries = new HashMap<String, String>();
     moreEntries.put("db.modeOfOperation", "urlAndMetadataLister");
     moreEntries.put("db.uniqueKey", "url:string");
     // Required for validation, but not specific to this test.
-    moreEntries.put("db.everyDocIdSql", "");
+    moreEntries.put("db.everyDocIdSql", "select url from data");
+    moreEntries.put("db.singleDocContentSql", "select id, url from data");
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage("requires docId.isUrl to be \"true\"");
     getObjectUnderTest(moreEntries);
@@ -934,12 +936,14 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitUrlMetadataLister_docIdIsUrlFalse() throws Exception {
+    executeUpdate("create table data(id integer, url varchar)");
     Map<String, String> moreEntries = new HashMap<String, String>();
     moreEntries.put("db.modeOfOperation", "urlAndMetadataLister");
     moreEntries.put("docId.isUrl", "false");
     moreEntries.put("db.uniqueKey", "url:string");
     // Required for validation, but not specific to this test.
-    moreEntries.put("db.everyDocIdSql", "");
+    moreEntries.put("db.everyDocIdSql", "select id, url from data");
+    moreEntries.put("db.singleDocContentSql", "select * from data");
     thrown.expect(InvalidConfigurationException.class);
     thrown.expectMessage("requires docId.isUrl to be \"true\"");
     getObjectUnderTest(moreEntries);

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -108,7 +108,8 @@ public class UniqueKeyTest {
 
   @Test
   public void testIntString() {
-    UniqueKey.Builder builder = new UniqueKey.Builder("numnum:int,strstr:string");
+    UniqueKey.Builder builder
+        = new UniqueKey.Builder("numnum:int,strstr:string");
     assertEquals(asList("numnum", "strstr"), builder.getDocIdSqlColumns());
     assertEquals(ColumnType.INT, builder.getColumnTypes().get("numnum"));
     assertEquals(ColumnType.STRING, builder.getColumnTypes().get("strstr"));
@@ -251,12 +252,13 @@ public class UniqueKeyTest {
         + "c4 date, c5 time, c6 timestamp)");
     executeUpdate("insert into data(c1, c2, c3, c4, c5, c6) "
         + "values (123, 4567890, 'foo', "
-        + "{d '2007-08-09'}, {t '12:34:56'}, {ts '2007-08-09T12:34:56'})");
+        + "{d '2007-08-09'}, {t '12:34:56'}, {ts '2007-08-09 12:34:56'})");
 
     UniqueKey uk = new UniqueKey.Builder(
         "c1:int, c2:long, c3:string, c4:date, c5:time, c6:timestamp").build();
     ResultSet rs = executeQueryAndNext("select * from data");
-    assertEquals("123/4567890/foo/2007-08-09/12:34:56/1186688096000",
+    assertEquals("123/4567890/foo/2007-08-09/12:34:56/"
+                 + Timestamp.valueOf("2007-08-09 12:34:56").getTime(),
                  uk.makeUniqueId(rs));
   }
 


### PR DESCRIPTION
This moved the various getters used by verifyColumnNames
and the tests from UniqueKey to its Builder, leaving UniqueKey
instance with its basic functionality.

This moved UniqueKey creation to the bottom of the adaptor init()
method, after verifyColumnNames gets a chance to populate the
types map.

Other changes:
  - had to fix up some DatabaseAdaptor tests, since
    configuration validation happens in a different order.
  - added UniqueKey tests to bring code coverage up to 98%.
  - removed the various test getters, and replaced their usage
    with the regular getters.