### PR TITLE
Reorder SQL type switch statements in canonical order.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -462,6 +462,37 @@ public class DatabaseAdaptor extends AbstractAdaptor {
       // This code does not support binary or structured types.
       Object value = null;
       switch (columnType) {
+        case Types.LONGVARCHAR:
+          try (Reader reader = rs.getCharacterStream(index)) {
+            if (reader != null) {
+              char[] buffer = new char[4096];
+              int len;
+              if ((len = reader.read(buffer)) != -1) {
+                value = new String(buffer, 0, len);
+              }
+            }
+          }
+          break;
+        case Types.LONGNVARCHAR:
+          try (Reader reader = rs.getNCharacterStream(index)) {
+            if (reader != null) {
+              char[] buffer = new char[4096];
+              int len;
+              if ((len = reader.read(buffer)) != -1) {
+                value = new String(buffer, 0, len);
+              }
+            }
+          }
+          break;
+        case Types.DATE:
+          value = rs.getDate(index);
+          break;
+        case Types.TIME:
+          value = rs.getTime(index);
+          break;
+        case Types.TIMESTAMP:
+          value = rs.getTimestamp(index);
+          break;
         case Types.CLOB:
           Clob clob = rs.getClob(index);
           if (clob != null) {
@@ -508,46 +539,15 @@ public class DatabaseAdaptor extends AbstractAdaptor {
             }
           }
           break;
-        case Types.LONGVARCHAR:
-          try (Reader reader = rs.getCharacterStream(index)) {
-            if (reader != null) {
-              char[] buffer = new char[4096];
-              int len;
-              if ((len = reader.read(buffer)) != -1) {
-                value = new String(buffer, 0, len);
-              }
-            }
-          }
-          break;
-        case Types.LONGNVARCHAR:
-          try (Reader reader = rs.getNCharacterStream(index)) {
-            if (reader != null) {
-              char[] buffer = new char[4096];
-              int len;
-              if ((len = reader.read(buffer)) != -1) {
-                value = new String(buffer, 0, len);
-              }
-            }
-          }
-          break;
-        case Types.DATE:
-          value = rs.getDate(index);
-          break;
-        case Types.TIME:
-          value = rs.getTime(index);
-          break;
-        case Types.TIMESTAMP:
-          value = rs.getTimestamp(index);
-          break;
         case Types.BINARY:
         case Types.VARBINARY:
         case Types.LONGVARBINARY:
-        case Types.BLOB:
         case -13: // Oracle BFILE.
+        case Types.BLOB:
         case Types.ARRAY:
-        case Types.JAVA_OBJECT:
         case Types.REF:
         case Types.STRUCT:
+        case Types.JAVA_OBJECT:
           log.log(Level.FINEST, "Metadata column type not supported: {0}",
               columnType);
           break;

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -1832,113 +1832,6 @@ public class DatabaseAdaptorTest {
   }
 
   @Test
-  public void testMetadataColumns_clob() throws Exception {
-    // NCLOB shows up as CLOB in H2
-    String content = "Hello World";
-    executeUpdate("create table data(id int, content clob)");
-    String sql = "insert into data(id, content) values (1, ?)";
-    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
-      ps.setString(1, content);
-      assertEquals(1, ps.executeUpdate());
-    }
-
-    Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.uniqueKey", "ID:int");
-    configEntries.put("db.everyDocIdSql", "select * from data");
-    configEntries.put("db.singleDocContentSql",
-        "select * from data where id = ?");
-    configEntries.put("db.modeOfOperation", "rowToText");
-    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
-
-    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
-    MockRequest request = new MockRequest(new DocId("1"));
-    RecordingResponse response = new RecordingResponse();
-    adaptor.getDocContent(request, response);
-
-    Metadata expected = new Metadata();
-    expected.add("col1", "1");
-    expected.add("col2", content);
-    assertEquals(expected, response.getMetadata());
-  }
-
-  @Test
-  public void testMetadataColumns_varchar() throws Exception {
-    // LONGVARCHAR, LONGNVARCHAR show up as VARCHAR in H2.
-    String content = "Hello World";
-    executeUpdate("create table data(id int, content varchar)");
-    String sql = "insert into data(id, content) values (1, ?)";
-    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
-      ps.setString(1, content);
-      assertEquals(1, ps.executeUpdate());
-    }
-
-    Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.uniqueKey", "ID:int");
-    configEntries.put("db.everyDocIdSql", "select * from data");
-    configEntries.put("db.singleDocContentSql",
-        "select * from data where id = ?");
-    configEntries.put("db.modeOfOperation", "rowToText");
-    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
-
-    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
-    MockRequest request = new MockRequest(new DocId("1"));
-    RecordingResponse response = new RecordingResponse();
-    adaptor.getDocContent(request, response);
-
-    Metadata expected = new Metadata();
-    expected.add("col1", "1");
-    expected.add("col2", content);
-    assertEquals(expected, response.getMetadata());
-  }
-
-  @Test
-  public void testMetadataColumns_integer() throws Exception {
-    executeUpdate("create table data(id int, content integer)");
-    executeUpdate("insert into data(id, content) values (1, 345697)");
-
-    Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.uniqueKey", "ID:int");
-    configEntries.put("db.everyDocIdSql", "select * from data");
-    configEntries.put("db.singleDocContentSql",
-        "select * from data where id = ?");
-    configEntries.put("db.modeOfOperation", "rowToText");
-    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
-
-    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
-    MockRequest request = new MockRequest(new DocId("1"));
-    RecordingResponse response = new RecordingResponse();
-    adaptor.getDocContent(request, response);
-
-    Metadata expected = new Metadata();
-    expected.add("col1", "1");
-    expected.add("col2", "345697");
-    assertEquals(expected, response.getMetadata());
-  }
-
-  @Test
-  public void testMetadataColumns_clobNull() throws Exception {
-    executeUpdate("create table data(id int, content clob)");
-    executeUpdate("insert into data(id) values (1)");
-
-    Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.uniqueKey", "ID:int");
-    configEntries.put("db.everyDocIdSql", "select * from data");
-    configEntries.put("db.singleDocContentSql",
-        "select * from data where id = ?");
-    configEntries.put("db.modeOfOperation", "rowToText");
-    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
-
-    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
-    MockRequest request = new MockRequest(new DocId("1"));
-    RecordingResponse response = new RecordingResponse();
-    adaptor.getDocContent(request, response);
-
-    Metadata expected = new Metadata();
-    expected.add("col1", "1");
-    assertEquals(expected, response.getMetadata());
-  }
-
-  @Test
   public void testMetadataColumns_date() throws Exception {
     executeUpdate("create table data(id integer, col date)");
     executeUpdate("insert into data(id, col) values(1001, {d '2004-10-06'})");
@@ -2078,6 +1971,113 @@ public class DatabaseAdaptorTest {
     Metadata metadata = new Metadata();
     metadata.add("col1", "1001");
     assertEquals(metadata, response.getMetadata());
+  }
+
+  @Test
+  public void testMetadataColumns_clob() throws Exception {
+    // NCLOB shows up as CLOB in H2
+    String content = "Hello World";
+    executeUpdate("create table data(id int, content clob)");
+    String sql = "insert into data(id, content) values (1, ?)";
+    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
+      ps.setString(1, content);
+      assertEquals(1, ps.executeUpdate());
+    }
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select * from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    expected.add("col2", content);
+    assertEquals(expected, response.getMetadata());
+  }
+
+  @Test
+  public void testMetadataColumns_clobNull() throws Exception {
+    executeUpdate("create table data(id int, content clob)");
+    executeUpdate("insert into data(id) values (1)");
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select * from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    assertEquals(expected, response.getMetadata());
+  }
+
+  @Test
+  public void testMetadataColumns_integer() throws Exception {
+    executeUpdate("create table data(id int, content integer)");
+    executeUpdate("insert into data(id, content) values (1, 345697)");
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select * from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    expected.add("col2", "345697");
+    assertEquals(expected, response.getMetadata());
+  }
+
+  @Test
+  public void testMetadataColumns_varchar() throws Exception {
+    // LONGVARCHAR, LONGNVARCHAR show up as VARCHAR in H2.
+    String content = "Hello World";
+    executeUpdate("create table data(id int, content varchar)");
+    String sql = "insert into data(id, content) values (1, ?)";
+    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
+      ps.setString(1, content);
+      assertEquals(1, ps.executeUpdate());
+    }
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select * from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    expected.add("col2", content);
+    assertEquals(expected, response.getMetadata());
   }
 
   @Test

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -2027,60 +2027,6 @@ public class DatabaseAdaptorTest {
   }
 
   @Test
-  public void testMetadataColumns_integer() throws Exception {
-    executeUpdate("create table data(id int, content integer)");
-    executeUpdate("insert into data(id, content) values (1, 345697)");
-
-    Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.uniqueKey", "ID:int");
-    configEntries.put("db.everyDocIdSql", "select * from data");
-    configEntries.put("db.singleDocContentSql",
-        "select * from data where id = ?");
-    configEntries.put("db.modeOfOperation", "rowToText");
-    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
-
-    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
-    MockRequest request = new MockRequest(new DocId("1"));
-    RecordingResponse response = new RecordingResponse();
-    adaptor.getDocContent(request, response);
-
-    Metadata expected = new Metadata();
-    expected.add("col1", "1");
-    expected.add("col2", "345697");
-    assertEquals(expected, response.getMetadata());
-  }
-
-  @Test
-  public void testMetadataColumns_varchar() throws Exception {
-    // LONGVARCHAR, LONGNVARCHAR show up as VARCHAR in H2.
-    String content = "Hello World";
-    executeUpdate("create table data(id int, content varchar)");
-    String sql = "insert into data(id, content) values (1, ?)";
-    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
-      ps.setString(1, content);
-      assertEquals(1, ps.executeUpdate());
-    }
-
-    Map<String, String> configEntries = new HashMap<String, String>();
-    configEntries.put("db.uniqueKey", "ID:int");
-    configEntries.put("db.everyDocIdSql", "select * from data");
-    configEntries.put("db.singleDocContentSql",
-        "select * from data where id = ?");
-    configEntries.put("db.modeOfOperation", "rowToText");
-    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
-
-    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
-    MockRequest request = new MockRequest(new DocId("1"));
-    RecordingResponse response = new RecordingResponse();
-    adaptor.getDocContent(request, response);
-
-    Metadata expected = new Metadata();
-    expected.add("col1", "1");
-    expected.add("col2", content);
-    assertEquals(expected, response.getMetadata());
-  }
-
-  @Test
   public void testMetadataColumns_blob() throws Exception {
     String content = "hello world";
     executeUpdate("create table data(id int, content blob)");
@@ -2195,6 +2141,60 @@ public class DatabaseAdaptorTest {
     assertEquals(messages.toString(), 1, messages.size());
     Metadata expected = new Metadata();
     expected.add("id", "1");
+    assertEquals(expected, response.getMetadata());
+  }
+
+  @Test
+  public void testMetadataColumns_integer() throws Exception {
+    executeUpdate("create table data(id int, content integer)");
+    executeUpdate("insert into data(id, content) values (1, 345697)");
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select * from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    expected.add("col2", "345697");
+    assertEquals(expected, response.getMetadata());
+  }
+
+  @Test
+  public void testMetadataColumns_varchar() throws Exception {
+    // LONGVARCHAR, LONGNVARCHAR show up as VARCHAR in H2.
+    String content = "Hello World";
+    executeUpdate("create table data(id int, content varchar)");
+    String sql = "insert into data(id, content) values (1, ?)";
+    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
+      ps.setString(1, content);
+      assertEquals(1, ps.executeUpdate());
+    }
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select * from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    expected.add("col2", content);
     assertEquals(expected, response.getMetadata());
   }
 

--- a/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
+++ b/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
@@ -112,94 +112,6 @@ public class TupleReaderTest {
   }
 
   @Test
-  public void testVarchar() throws Exception {
-    executeUpdate("create table data(colname varchar)");
-    executeUpdate("insert into data(colname) values('onevalue')");
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"VARCHAR\">onevalue</COLNAME>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
-  public void testVarchar_xml() throws Exception {
-    final String template = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"VARCHAR\">%s</COLNAME>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    String xml = String.format(template, "onevalue");
-    executeUpdate("create table data(colname varchar)");
-    executeUpdate("insert into data(colname) values('" + xml + "')");
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(
-        String.format(template, xml.replace("<", "&lt;").replace(">", "&gt;")),
-        result);
-  }
-
-  @Test
-  public void testVarchar_null() throws Exception {
-    executeUpdate("create table data(colname varchar)");
-    executeUpdate("insert into data(colname) values(null)");
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"VARCHAR\" ISNULL=\"true\"/>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
-  public void testChar() throws Exception {
-    executeUpdate("create table data(colname char)");
-    executeUpdate("insert into data(colname) values('onevalue')");
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"CHAR\">onevalue</COLNAME>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
-  public void testChar_null() throws Exception {
-    executeUpdate("create table data(colname char)");
-    executeUpdate("insert into data(colname) values(null)");
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"CHAR\" ISNULL=\"true\"/>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
   public void testInteger() throws Exception {
     executeUpdate("create table data(colname integer)");
     executeUpdate("insert into data(colname) values(17)");
@@ -268,6 +180,94 @@ public class TupleReaderTest {
   }
 
   @Test
+  public void testChar() throws Exception {
+    executeUpdate("create table data(colname char)");
+    executeUpdate("insert into data(colname) values('onevalue')");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"CHAR\">onevalue</COLNAME>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testChar_null() throws Exception {
+    executeUpdate("create table data(colname char)");
+    executeUpdate("insert into data(colname) values(null)");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"CHAR\" ISNULL=\"true\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testVarchar() throws Exception {
+    executeUpdate("create table data(colname varchar)");
+    executeUpdate("insert into data(colname) values('onevalue')");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"VARCHAR\">onevalue</COLNAME>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testVarchar_xml() throws Exception {
+    final String template = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"VARCHAR\">%s</COLNAME>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    String xml = String.format(template, "onevalue");
+    executeUpdate("create table data(colname varchar)");
+    executeUpdate("insert into data(colname) values('" + xml + "')");
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(
+        String.format(template, xml.replace("<", "&lt;").replace(">", "&gt;")),
+        result);
+  }
+
+  @Test
+  public void testVarchar_null() throws Exception {
+    executeUpdate("create table data(colname varchar)");
+    executeUpdate("insert into data(colname) values(null)");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"VARCHAR\" ISNULL=\"true\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
   public void testDate() throws Exception {
     executeUpdate("create table data(colname date)");
     executeUpdate("insert into data(colname) values({d '2004-10-06'})");
@@ -293,6 +293,60 @@ public class TupleReaderTest {
         + "<table>"
         + "<table_rec>"
         + "<COLNAME SQLType=\"DATE\" ISNULL=\"true\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testTime() throws Exception {
+    executeUpdate("create table data(colname time)");
+    executeUpdate("insert into data(colname) values({t '09:15:30'})");
+    // H2 returns a java.sql.Date with the date set to 1970-01-01.
+    final DateFormat timeZoneFmt = new SimpleDateFormat("X");
+    Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+    cal.set(Calendar.YEAR, 1970);
+    cal.set(Calendar.MONTH, Calendar.JANUARY);
+    cal.set(Calendar.DATE, 1);
+    cal.set(Calendar.HOUR, 9);
+    cal.set(Calendar.MINUTE, 15);
+    cal.set(Calendar.SECOND, 30);
+    Date date = cal.getTime();
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"TIME\">09:15:30"
+        + timeZoneFmt.format(date) + ":00"
+        + "</COLNAME>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testTime_null() throws Exception {
+    executeUpdate("create table data(colname time)");
+    executeUpdate("insert into data(colname) values(null)");
+    // H2 returns a java.sql.Date with the date set to 1970-01-01.
+    Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+    cal.set(Calendar.YEAR, 1970);
+    cal.set(Calendar.MONTH, Calendar.JANUARY);
+    cal.set(Calendar.DATE, 1);
+    cal.set(Calendar.HOUR, 9);
+    cal.set(Calendar.MINUTE, 15);
+    cal.set(Calendar.SECOND, 30);
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"TIME\" ISNULL=\"true\"/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";
@@ -432,60 +486,6 @@ public class TupleReaderTest {
   }
 
   @Test
-  public void testTime() throws Exception {
-    executeUpdate("create table data(colname time)");
-    executeUpdate("insert into data(colname) values({t '09:15:30'})");
-    // H2 returns a java.sql.Date with the date set to 1970-01-01.
-    final DateFormat timeZoneFmt = new SimpleDateFormat("X");
-    Calendar cal = Calendar.getInstance(TimeZone.getDefault());
-    cal.set(Calendar.YEAR, 1970);
-    cal.set(Calendar.MONTH, Calendar.JANUARY);
-    cal.set(Calendar.DATE, 1);
-    cal.set(Calendar.HOUR, 9);
-    cal.set(Calendar.MINUTE, 15);
-    cal.set(Calendar.SECOND, 30);
-    Date date = cal.getTime();
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"TIME\">09:15:30"
-        + timeZoneFmt.format(date) + ":00"
-        + "</COLNAME>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
-  public void testTime_null() throws Exception {
-    executeUpdate("create table data(colname time)");
-    executeUpdate("insert into data(colname) values(null)");
-    // H2 returns a java.sql.Date with the date set to 1970-01-01.
-    Calendar cal = Calendar.getInstance(TimeZone.getDefault());
-    cal.set(Calendar.YEAR, 1970);
-    cal.set(Calendar.MONTH, Calendar.JANUARY);
-    cal.set(Calendar.DATE, 1);
-    cal.set(Calendar.HOUR, 9);
-    cal.set(Calendar.MINUTE, 15);
-    cal.set(Calendar.SECOND, 30);
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"TIME\" ISNULL=\"true\"/>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
   public void testBlob() throws Exception {
     byte[] blobData = new byte[12345];
     new Random().nextBytes(blobData);
@@ -503,40 +503,6 @@ public class TupleReaderTest {
         + "<COLNAME SQLType=\"BLOB\" encoding=\"base64binary\">"
         + base64BlobData
         + "</COLNAME>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
-  public void testBlob_empty() throws Exception {
-    executeUpdate("create table data(colname blob)");
-    executeUpdate("insert into data(colname) values('')");
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"BLOB\" encoding=\"base64binary\"/>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
-  public void testBlob_null() throws Exception {
-    executeUpdate("create table data(colname blob)");
-    executeUpdate("insert into data(colname) values(null)");
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"BLOB\" ISNULL=\"true\"/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";
@@ -595,6 +561,40 @@ public class TupleReaderTest {
         + "<table>"
         + "<table_rec>"
         + "<COLNAME SQLType=\"CLOB\" ISNULL=\"true\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testBlob_empty() throws Exception {
+    executeUpdate("create table data(colname blob)");
+    executeUpdate("insert into data(colname) values('')");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"BLOB\" encoding=\"base64binary\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testBlob_null() throws Exception {
+    executeUpdate("create table data(colname blob)");
+    executeUpdate("insert into data(colname) values(null)");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"BLOB\" ISNULL=\"true\"/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";

--- a/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
+++ b/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
@@ -268,6 +268,66 @@ public class TupleReaderTest {
   }
 
   @Test
+  public void testBinary() throws Exception {
+    byte[] binaryData = new byte[123];
+    new Random().nextBytes(binaryData);
+    executeUpdate("create table data(colname binary)");
+    String sql = "insert into data(colname) values (?)";
+    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
+      ps.setBinaryStream(1, new ByteArrayInputStream(binaryData));
+      assertEquals(1, ps.executeUpdate());
+    }
+    String base64BinaryData = DatatypeConverter.printBase64Binary(binaryData);
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"VARBINARY\" encoding=\"base64binary\">"
+        + base64BinaryData
+        + "</COLNAME>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testBinary_empty() throws Exception {
+    executeUpdate("create table data(colname binary)");
+    executeUpdate("insert into data(colname) values('')");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"VARBINARY\" encoding=\"base64binary\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testBinary_null() throws Exception {
+    executeUpdate("create table data(colname binary)");
+    executeUpdate("insert into data(colname) values(null)");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"VARBINARY\" ISNULL=\"true\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
   public void testDate() throws Exception {
     executeUpdate("create table data(colname date)");
     executeUpdate("insert into data(colname) values({d '2004-10-06'})");
@@ -486,32 +546,6 @@ public class TupleReaderTest {
   }
 
   @Test
-  public void testBlob() throws Exception {
-    byte[] blobData = new byte[12345];
-    new Random().nextBytes(blobData);
-    executeUpdate("create table data(colname blob)");
-    String sql = "insert into data(colname) values (?)";
-    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
-      ps.setBinaryStream(1, new ByteArrayInputStream(blobData));
-      assertEquals(1, ps.executeUpdate());
-    }
-    String base64BlobData = DatatypeConverter.printBase64Binary(blobData);
-    final String golden = ""
-        + "<database>"
-        + "<table>"
-        + "<table_rec>"
-        + "<COLNAME SQLType=\"BLOB\" encoding=\"base64binary\">"
-        + base64BlobData
-        + "</COLNAME>"
-        + "</table_rec>"
-        + "</table>"
-        + "</database>";
-    ResultSet rs = executeQueryAndNext("select * from data");
-    String result = generateXml(rs);
-    assertEquals(golden, result);
-  }
-
-  @Test
   public void testClob() throws Exception {
     String clobData =
         " Google's indices consist of information that has been"
@@ -561,6 +595,32 @@ public class TupleReaderTest {
         + "<table>"
         + "<table_rec>"
         + "<COLNAME SQLType=\"CLOB\" ISNULL=\"true\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testBlob() throws Exception {
+    byte[] blobData = new byte[12345];
+    new Random().nextBytes(blobData);
+    executeUpdate("create table data(colname blob)");
+    String sql = "insert into data(colname) values (?)";
+    try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
+      ps.setBinaryStream(1, new ByteArrayInputStream(blobData));
+      assertEquals(1, ps.executeUpdate());
+    }
+    String base64BlobData = DatatypeConverter.printBase64Binary(blobData);
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"BLOB\" encoding=\"base64binary\">"
+        + base64BlobData
+        + "</COLNAME>"
         + "</table_rec>"
         + "</table>"
         + "</database>";


### PR DESCRIPTION
Order to match the tables in the JDBC API Tutorial and Reference 3/e:
numeric, boolean, character, binary, data-time, LOBs, and structured.
Within each group, smaller to larger. Date-time order is DATE, TIME,
TIMESTAMP. LOB order is CLOB, NCLOB, BLOB, SQLXML. Structured order is
ARRAY, REF, STRUCT, JAVA_OBJECT.

Unsupported types are grouped together in the last block before the
default label, in canonical order.

Reorder the tests to match the switch statements.

The only non-reordering change is to add BFILE to the switch in
TupleReader, matching the other three switches (RowToHtml,
ContentColumn, and DatabaseAdaptor).