### PR TITLE
Fix several existing tests that were broken on MySQL

### DIFF
--- a/build.properties.sample
+++ b/build.properties.sample
@@ -11,7 +11,7 @@ build.bootclasspath = ${jdk7.home}/jre/lib/rt.jar\
     :${jdk7.home}/jre/lib/jce.jar
 
 # Classpath of JDBC drivers for "ant run" and "ant test".
-# jdbc.classpath = path/to/JDBC/driver
+# jdbc.classpath =
 
 # By default, the unit tests use an in-memory H2 database.
 # However, you can configure a different database to use for the
@@ -20,7 +20,7 @@ build.bootclasspath = ${jdk7.home}/jre/lib/rt.jar\
 # Supported databases: H2, MySQL, Oracle, SQLServer
 # test.jdbc.database = MySQL
 # test.jdbc.driver = com.mysql.jdbc.Driver
-# test.jdbc.url = jdbc:mysql://address=(useSSL=false)(protocol=tcp)(host=localhost)(port=3306)/test
+# test.jdbc.url = jdbc:mysql://address=(useSSL=false)(protocol=tcp)(host=localhost)(port=3306)/test?sessionVariables=sql_mode='ANSI_QUOTES'
 # test.jdbc.user =
 # test.jdbc.password =
 #

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -805,9 +805,10 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitMetadataColumns_trueBlank() throws Exception {
+    // Note: MySQL is case-preserving in column names on table creation.
     executeUpdate(
         "create table data(ID int, FOO varchar(20), BAR varchar(20))");
-    executeUpdate("insert into data(ID, FOO, BAR) "
+    executeUpdate("insert into data(id, foo, bar) "
                   + "values(1, 'fooVal', 'barVal')");
 
     Map<String, String> moreEntries = new HashMap<String, String>();
@@ -815,10 +816,10 @@ public class DatabaseAdaptorTest {
     moreEntries.put("db.metadataColumns", "");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.modeOfOperation", "rowToText");
-    moreEntries.put("db.uniqueKey", "ID:int");
+    moreEntries.put("db.uniqueKey", "id:int");
     moreEntries.put("db.everyDocIdSql", "select ID from data");
     moreEntries.put("db.singleDocContentSql",
-        "select * from data where ID = ?");
+        "select * from data where id = ?");
 
     DatabaseAdaptor adaptor = getObjectUnderTest(moreEntries);
     ResultSet resultSet = executeQueryAndNext("select * from data");

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -806,8 +806,8 @@ public class DatabaseAdaptorTest {
   @Test
   public void testInitMetadataColumns_trueBlank() throws Exception {
     executeUpdate(
-        "create table data(id int, foo varchar(20), bar varchar(20))");
-    executeUpdate("insert into data(id, foo, bar) "
+        "create table data(ID int, FOO varchar(20), BAR varchar(20))");
+    executeUpdate("insert into data(ID, FOO, BAR) "
                   + "values(1, 'fooVal', 'barVal')");
 
     Map<String, String> moreEntries = new HashMap<String, String>();
@@ -815,10 +815,10 @@ public class DatabaseAdaptorTest {
     moreEntries.put("db.metadataColumns", "");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.modeOfOperation", "rowToText");
-    moreEntries.put("db.uniqueKey", "id:int");
-    moreEntries.put("db.everyDocIdSql", "select id from data");
+    moreEntries.put("db.uniqueKey", "ID:int");
+    moreEntries.put("db.everyDocIdSql", "select ID from data");
     moreEntries.put("db.singleDocContentSql",
-        "select * from data where id = ?");
+        "select * from data where ID = ?");
 
     DatabaseAdaptor adaptor = getObjectUnderTest(moreEntries);
     ResultSet resultSet = executeQueryAndNext("select * from data");
@@ -826,9 +826,9 @@ public class DatabaseAdaptorTest {
     adaptor.addMetadataToRecordBuilder(builder, resultSet);
 
     Metadata golden = new Metadata();
-    golden.add((is(MYSQL) ? "id" : "ID"), "1");
-    golden.add((is(MYSQL) ? "foo" : "FOO"), "fooVal");
-    golden.add((is(MYSQL) ? "bar" : "BAR"), "barVal");
+    golden.add("ID", "1");
+    golden.add("FOO", "fooVal");
+    golden.add("BAR", "barVal");
     assertEquals(golden, builder.build().getMetadata());
   }
 

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -16,10 +16,12 @@ package com.google.enterprise.adaptor.database;
 
 import static com.google.enterprise.adaptor.DocIdPusher.Record;
 import static com.google.enterprise.adaptor.Principal.DEFAULT_NAMESPACE;
+import static com.google.enterprise.adaptor.database.JdbcFixture.Database.MYSQL;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeQuery;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeQueryAndNext;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeUpdate;
 import static com.google.enterprise.adaptor.database.JdbcFixture.getConnection;
+import static com.google.enterprise.adaptor.database.JdbcFixture.is;
 import static com.google.enterprise.adaptor.database.Logging.captureLogMessages;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.US;
@@ -34,6 +36,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.enterprise.adaptor.Acl;
 import com.google.enterprise.adaptor.AuthnIdentity;
@@ -823,9 +826,9 @@ public class DatabaseAdaptorTest {
     adaptor.addMetadataToRecordBuilder(builder, resultSet);
 
     Metadata golden = new Metadata();
-    golden.add("ID", "1");
-    golden.add("FOO", "fooVal");
-    golden.add("BAR", "barVal");
+    golden.add((is(MYSQL) ? "id" : "ID"), "1");
+    golden.add((is(MYSQL) ? "foo" : "FOO"), "fooVal");
+    golden.add((is(MYSQL) ? "bar" : "BAR"), "barVal");
     assertEquals(golden, builder.build().getMetadata());
   }
 
@@ -2221,7 +2224,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_timestamp() throws Exception {
-    executeUpdate("create table data(id integer, col timestamp)");
+    executeUpdate("create table data(id integer, col timestamp(3))");
     executeUpdate("insert into data(id, col) values(1001, "
         + "{ts '2009-10-05 09:20:49.512'})");
 
@@ -2246,7 +2249,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_timestampNull() throws Exception {
-    executeUpdate("create table data(id integer, col timestamp)");
+    executeUpdate("create table data(id integer, col timestamp null)");
     executeUpdate("insert into data(id) values(1001)");
 
     Map<String, String> moreEntries = new HashMap<String, String>();
@@ -2269,6 +2272,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_clob() throws Exception {
+    assumeFalse("MySQL does not support clobs", is(MYSQL));
     // NCLOB shows up as CLOB in H2
     String content = "Hello World";
     executeUpdate("create table data(id int, content clob)");
@@ -2299,6 +2303,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_clobNull() throws Exception {
+    assumeFalse("MySQL does not support clobs", is(MYSQL));
     executeUpdate("create table data(id int, content clob)");
     executeUpdate("insert into data(id) values (1)");
 
@@ -2381,6 +2386,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_array() throws Exception {
+    assumeFalse("MySQL does not support arrays", is(MYSQL));
     String[] content = { "hello", "world" };
     executeUpdate("create table data(id int, content array)");
     String sql = "insert into data(id, content) values (1, ?)";
@@ -2413,6 +2419,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_arrayNull() throws Exception {
+    assumeFalse("MySQL does not support arrays", is(MYSQL));
     executeUpdate("create table data(id int, content array)");
     executeUpdate("insert into data(id) values (1)");
 

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -805,7 +805,8 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testInitMetadataColumns_trueBlank() throws Exception {
-    // Note: MySQL is case-preserving in column names on table creation.
+    // Note: MySQL is case-preserving in column names on table creation
+    // and Metadata.equals() is case-sensitive.
     executeUpdate(
         "create table data(ID int, FOO varchar(20), BAR varchar(20))");
     executeUpdate("insert into data(id, foo, bar) "
@@ -817,7 +818,7 @@ public class DatabaseAdaptorTest {
     // Required for validation, but not specific to this test.
     moreEntries.put("db.modeOfOperation", "rowToText");
     moreEntries.put("db.uniqueKey", "id:int");
-    moreEntries.put("db.everyDocIdSql", "select ID from data");
+    moreEntries.put("db.everyDocIdSql", "select id from data");
     moreEntries.put("db.singleDocContentSql",
         "select * from data where id = ?");
 

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -2249,7 +2249,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_timestampNull() throws Exception {
-    executeUpdate("create table data(id integer, col timestamp null)");
+    executeUpdate("create table data(id integer, col timestamp default null)");
     executeUpdate("insert into data(id) values(1001)");
 
     Map<String, String> moreEntries = new HashMap<String, String>();


### PR DESCRIPTION
- MySQL does not support CLOBs or ARRAYs
- Specify nullable timestamps when nulling them
- Specify millisecond resolution for timestamps when required
- MySQL columns are case-sensitive

Tests that remain broken:
 - all that use dateadd()