### PR TITLE
Changes to pass most tests on Oracle

### DIFF
--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -2430,14 +2430,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_array() throws Exception {
-    assumeTrue("ARRAY type not supported", is(H2));
-    if (is(ORACLE)) {
-      executeUpdate(
-          "create or replace type vcarray as varray(2) of varchar2(20)");
-      executeUpdate("create table data(id int, content vcarray)");
-      executeUpdate("insert into data(id, content) "
-          + "values (1, vcarray('hello', 'world'))");
-    } else {
+    if (is(H2)) {
       String[] content = {"hello", "world"};
       executeUpdate("create table data(id int, content array)");
       String sql = "insert into data(id, content) values (1, ?)";
@@ -2445,6 +2438,14 @@ public class DatabaseAdaptorTest {
         ps.setObject(1, content);
         assertEquals(1, ps.executeUpdate());
       }
+    } else if (is(ORACLE)) {
+      executeUpdate(
+          "create or replace type vcarray as varray(2) of varchar2(20)");
+      executeUpdate("create table data(id int, content vcarray)");
+      executeUpdate("insert into data(id, content) "
+          + "values (1, vcarray('hello', 'world'))");
+    } else {
+      assumeTrue("ARRAY type not supported", false);
     }
 
     Map<String, String> configEntries = new HashMap<String, String>();
@@ -2471,15 +2472,16 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_arrayNull() throws Exception {
-    assumeTrue("ARRAY type not supported", is(H2));
-    if (is(ORACLE)) {
+    if(is(H2)) {
+      executeUpdate("create table data(id int, content array)");
+      executeUpdate("insert into data(id) values (1)");
+    } else if (is(ORACLE)) {
       executeUpdate(
           "create or replace type vcarray as varray(2) of varchar2(20)");
       executeUpdate("create table data(id int, content vcarray)");
       executeUpdate("insert into data(id) values (1)");
     } else {
-      executeUpdate("create table data(id int, content array)");
-      executeUpdate("insert into data(id) values (1)");
+      assumeTrue("ARRAY type not supported", false);
     }
 
     Map<String, String> configEntries = new HashMap<String, String>();

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -2446,10 +2446,9 @@ public class DatabaseAdaptorTest {
       String[] content = {"hello", "world"};
       executeUpdate("create table data(id int, content array)");
       String sql = "insert into data(id, content) values (1, ?)";
-      try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
-        ps.setObject(1, content);
-        assertEquals(1, ps.executeUpdate());
-      }
+      PreparedStatement ps = getConnection().prepareStatement(sql);
+      ps.setObject(1, content);
+      assertEquals(1, ps.executeUpdate());
     } else if (is(ORACLE)) {
       executeUpdate(
           "create or replace type vcarray as varray(2) of varchar2(20)");

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -2484,7 +2484,7 @@ public class DatabaseAdaptorTest {
 
   @Test
   public void testMetadataColumns_arrayNull() throws Exception {
-    if(is(H2)) {
+    if (is(H2)) {
       executeUpdate("create table data(id int, content array)");
       executeUpdate("insert into data(id) values (1)");
     } else if (is(ORACLE)) {

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -2446,7 +2446,7 @@ public class DatabaseAdaptorTest {
       String[] content = {"hello", "world"};
       executeUpdate("create table data(id int, content array)");
       String sql = "insert into data(id, content) values (1, ?)";
-      PreparedStatement ps = getConnection().prepareStatement(sql);
+      PreparedStatement ps = prepareStatement(sql);
       ps.setObject(1, content);
       assertEquals(1, ps.executeUpdate());
     } else if (is(ORACLE)) {

--- a/test/com/google/enterprise/adaptor/database/JdbcFixture.java
+++ b/test/com/google/enterprise/adaptor/database/JdbcFixture.java
@@ -198,6 +198,11 @@ class JdbcFixture {
                   .replace("longvarbinary", "long varbinary")
                   .replace("clob", "text");
             }
+            if (sql.startsWith("insert")) {
+              sql = sql.replaceAll(
+                  "(\\d\\d\\d\\d-\\d\\d-\\d\\d)T(\\d\\d:\\d\\d:\\d\\d)",
+                  "$1 $2");
+            }
             break;
           case ORACLE:
             if (sql.startsWith("create table")) {
@@ -210,11 +215,6 @@ class JdbcFixture {
                   .replace("clob", "varchar(max)");
             }
             break;
-        }
-        if (sql.startsWith("insert")) {
-          sql = sql.replaceAll(
-              "(\\d\\d\\d\\d-\\d\\d-\\d\\d)T(\\d\\d:\\d\\d:\\d\\d)",
-              "$1 $2");
         }
         stmt.executeUpdate(sql);
       }

--- a/test/com/google/enterprise/adaptor/database/JdbcFixture.java
+++ b/test/com/google/enterprise/adaptor/database/JdbcFixture.java
@@ -136,7 +136,7 @@ class JdbcFixture {
             + "where table_schema = (select database())", "table_name");
         break;
       case ORACLE:
-        // TODO (srinivas): drop tables for Oracle database.
+        dropDatabaseTables("select table_name from user_tables", "table_name");
         break;
       case SQLSERVER:
         dropDatabaseTables("select name from sys.tables", "name");
@@ -197,12 +197,17 @@ class JdbcFixture {
                   .replace("longvarbinary", "long varbinary")
                   .replace("clob", "text");
             }
-            if (sql.startsWith("insert")) {
-              sql = sql.replaceAll(
-                  "(\\d\\d\\d\\d-\\d\\d-\\d\\d)T(\\d\\d:\\d\\d:\\d\\d)",
-                  "$1 $2");
+            break;
+          case ORACLE:
+            if (sql.startsWith("create table")) {
+              sql = sql.replaceAll("varbinary", "raw(1024)");
             }
             break;
+        }
+        if (sql.startsWith("insert")) {
+          sql = sql.replaceAll(
+              "(\\d\\d\\d\\d-\\d\\d-\\d\\d)T(\\d\\d:\\d\\d:\\d\\d)",
+              "$1 $2");
         }
         stmt.executeUpdate(sql);
       }

--- a/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
+++ b/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
@@ -16,7 +16,6 @@ package com.google.enterprise.adaptor.database;
 
 import static com.google.enterprise.adaptor.database.JdbcFixture.Database.H2;
 import static com.google.enterprise.adaptor.database.JdbcFixture.Database.MYSQL;
-import static com.google.enterprise.adaptor.database.JdbcFixture.Database.ORACLE;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeQueryAndNext;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeUpdate;
 import static com.google.enterprise.adaptor.database.JdbcFixture.is;
@@ -28,7 +27,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.enterprise.adaptor.InvalidConfigurationException;
@@ -317,7 +315,6 @@ public class ResponseGeneratorTest {
 
   @Test
   public void testContentColumn_varbinary() throws Exception {
-    assumeFalse("Oracle does not support varbinary", is(ORACLE));
     String content = "hello world";
     executeUpdate("create table data(id int, content varbinary(20))");
     String sql = "insert into data(id, content) values (1, ?)";

--- a/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
+++ b/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
@@ -578,7 +578,7 @@ public class ResponseGeneratorTest {
   @Test
   public void testUrlAndMetadataLister_nullUrl() throws Exception {
     executeUpdate("create table data(url varchar(200))");
-    executeUpdate("insert into data(url) values (NULL)");
+    executeUpdate("insert into data(url) values (null)");
 
     MockResponse uar = new MockResponse();
     Response response = newProxyInstance(Response.class, uar);

--- a/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
+++ b/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
@@ -16,6 +16,7 @@ package com.google.enterprise.adaptor.database;
 
 import static com.google.enterprise.adaptor.database.JdbcFixture.Database.H2;
 import static com.google.enterprise.adaptor.database.JdbcFixture.Database.MYSQL;
+import static com.google.enterprise.adaptor.database.JdbcFixture.Database.ORACLE;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeQueryAndNext;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeUpdate;
 import static com.google.enterprise.adaptor.database.JdbcFixture.is;
@@ -27,6 +28,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.enterprise.adaptor.InvalidConfigurationException;
@@ -315,6 +317,7 @@ public class ResponseGeneratorTest {
 
   @Test
   public void testContentColumn_varbinary() throws Exception {
+    assumeFalse("Oracle does not support varbinary", is(ORACLE));
     String content = "hello world";
     executeUpdate("create table data(id int, content varbinary(20))");
     String sql = "insert into data(id, content) values (1, ?)";
@@ -578,7 +581,7 @@ public class ResponseGeneratorTest {
   @Test
   public void testUrlAndMetadataLister_nullUrl() throws Exception {
     executeUpdate("create table data(url varchar(200))");
-    executeUpdate("insert into data() values ()");
+    executeUpdate("insert into data(url) values (NULL)");
 
     MockResponse uar = new MockResponse();
     Response response = newProxyInstance(Response.class, uar);


### PR DESCRIPTION
  - Add separate insert statements.
  - Skip tests that use unsupported data types.
  - 116 tests out of 117 pass in DatabaseAdaptorTest
  - 35 test out of 43 pass in ResponseGeneratorTest