### PR TITLE
Run all tests even when some fail.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -257,8 +257,10 @@ lib/plexi submodule or add the the command line argument
     description="Run instrumented tests and generate coverage report"/>
 
   <target name="test" depends="build" description="Run JUnit tests">
-    <junit printsummary="yes" haltonfailure="no" failureproperty="test.failure"
-           forkmode="once" fork="true" dir="${basedir}" maxmemory="512m">
+    <property name="build.haltonfailure" value="off"/>
+    <junit printsummary="yes"
+      haltonfailure="${build.haltonfailure}" failureproperty="build.failure"
+      forkmode="once" fork="true" dir="${basedir}" maxmemory="512m">
       <sysproperty key="net.sourceforge.cobertura.datafile"
         file="${build-instrument.dir}/cobertura.ser"/>
       <sysproperty key="build.properties" file="build.properties"/>
@@ -277,7 +279,7 @@ lib/plexi submodule or add the the command line argument
         </fileset>
       </batchtest>
     </junit>
-    <fail if="test.failure" message="Test failure"/>
+    <fail if="build.failure" message="Test failure"/>
   </target>
 
   <target name="instrument" depends="build" description="Instrument classes">

--- a/build.xml
+++ b/build.xml
@@ -257,8 +257,8 @@ lib/plexi submodule or add the the command line argument
     description="Run instrumented tests and generate coverage report"/>
 
   <target name="test" depends="build" description="Run JUnit tests">
-    <junit printsummary="yes" haltonfailure="yes" forkmode="once" fork="true"
-      dir="${basedir}" maxmemory="512m">
+    <junit printsummary="yes" haltonfailure="no" failureproperty="test.failure"
+           forkmode="once" fork="true" dir="${basedir}" maxmemory="512m">
       <sysproperty key="net.sourceforge.cobertura.datafile"
         file="${build-instrument.dir}/cobertura.ser"/>
       <sysproperty key="build.properties" file="build.properties"/>
@@ -277,6 +277,7 @@ lib/plexi submodule or add the the command line argument
         </fileset>
       </batchtest>
     </junit>
+    <fail if="test.failure" message="Test failure"/>
   </target>
 
   <target name="instrument" depends="build" description="Instrument classes">


### PR DESCRIPTION
Use haltonfailure="no" to run all test classes, but we still need to
fail in the test target in order to stop the build for the dist
target.