### PR TITLE
Pass all tests against SQL Server.

### DIFF
--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -1835,8 +1835,10 @@ public class DatabaseAdaptorTest {
     Map<String, String> moreEntries = new HashMap<String, String>();
     moreEntries.put("db.modeOfOperation", "rowToText");
     moreEntries.put("db.uniqueKey", "id:int");
-    moreEntries.put("db.updateSql",
-        "select id, null as gsa_timestamp from data where ts >= ? order by id");
+    String nullTimestamp =
+        is(SQLSERVER) ? "cast(null as datetime2)" : "null";
+    moreEntries.put("db.updateSql", "select id, " + nullTimestamp
+        + " as gsa_timestamp from data where ts >= ? order by id");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.everyDocIdSql", "select id from data");
     moreEntries.put("db.singleDocContentSql",

--- a/test/com/google/enterprise/adaptor/database/JdbcFixture.java
+++ b/test/com/google/enterprise/adaptor/database/JdbcFixture.java
@@ -194,25 +194,27 @@ class JdbcFixture {
         switch (DATABASE) {
           case MYSQL:
             if (sql.startsWith("create table")) {
-              sql = sql.replaceAll("(timestamp(\\(\\d\\))?)", "datetime$2 null")
-                  .replace("longvarbinary", "long varbinary")
-                  .replace("clob", "text");
-            }
-            if (sql.startsWith("insert")) {
-              sql = sql.replaceAll(
-                  "(\\d\\d\\d\\d-\\d\\d-\\d\\d)T(\\d\\d:\\d\\d:\\d\\d)",
-                  "$1 $2");
+              sql = sql
+                  .replaceAll("\\bclob\\b", "text")
+                  .replaceAll("\\blongvarbinary\\b", "long varbinary")
+                  .replaceAll("\\btimestamp\\b(\\(\\d\\))?", "datetime$1 null");
             }
             break;
           case ORACLE:
             if (sql.startsWith("create table")) {
-              sql = sql.replaceAll("varbinary", "raw(1024)");
+              sql = sql.replaceAll("\\bvarbinary\\b", "raw(1024)");
             }
             break;
           case SQLSERVER:
             if (sql.startsWith("create table")) {
-              sql = sql.replace("blob", "varbinary(max)")
-                  .replace("clob", "varchar(max)");
+              sql = sql
+                  .replaceAll("\\bblob\\b", "varbinary(max)")
+                  .replaceAll("\\bclob\\b", "varchar(max)")
+                  .replaceAll("\\btimestamp\\b", "datetime2");
+            } else if (sql.startsWith("insert")) {
+              // A ts escape is treated as a datetime rather than a
+              // datetime2, and rounded incorrectly. Use a string literal.
+              sql = sql.replaceAll("\\{ts ('[^']*')\\}", "$1");
             }
             break;
         }

--- a/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
+++ b/test/com/google/enterprise/adaptor/database/ResponseGeneratorTest.java
@@ -24,6 +24,7 @@ import static com.google.enterprise.adaptor.database.Logging.captureLogMessages;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.US;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -188,7 +189,7 @@ public class ResponseGeneratorTest {
     executeUpdate("create table data ("
         + "intcol integer, booleancol " + JdbcFixture.BOOLEAN
         + ", charcol varchar(20),"
-        + " datecol date, timecol time, tymestampcol timestamp(3),"
+        + " datecol date, timecol time, timestampcol timestamp(3),"
         + " clobcol clob, blobcol blob)");
     String sql = "insert into data values (1, ?, ?,"
         + "{d '2007-08-09'}, {t '12:34:56'}, {ts '2007-08-09 12:34:56.7'},"
@@ -213,7 +214,7 @@ public class ResponseGeneratorTest {
     String tables = is(SQLSERVER)
         ? ",,,,,," : "data,data,data,data,data,data,data";
     String golden = tables + "\n"
-        + "intcol,booleancol,charcol,datecol,timecol,tymestampcol,clobcol\n"
+        + "intcol,booleancol,charcol,datecol,timecol,timestampcol,clobcol\n"
         + "1,true,\"hello, world\",2007-08-09,12:34:56,2007-08-09 12:34:56.7,"
         + "it's a big world\n";
     assertEquals(golden, bar.baos.toString(UTF_8.name()).toLowerCase(US));
@@ -255,10 +256,9 @@ public class ResponseGeneratorTest {
 
     ResultSet rs = executeQueryAndNext("select * from data");
     resgen.generateResponse(rs, response);
-    String table = is(SQLSERVER) ? ",," : "DATA,DATA,DATA";
-    String golden = table + "\nID,NAME,QUOTE\n"
+    String golden = "\nID,NAME,QUOTE\n"
         + "1,Rhett Butler,\"\"\"Frankly Scarlett, I don't give a damn!\"\"\"\n";
-    assertEquals(golden, bar.baos.toString(UTF_8.name()));
+    assertThat(bar.baos.toString(UTF_8.name()), endsWith(golden));
   }
 
   @Test


### PR DESCRIPTION
* SQL NULL cannot be read as a datetime2 without a cast.
* SQL CHAR is padded with trailing spaces to the given size.
* Use bit for BOOLEAN.
* Use varbinary(max) and varchar(max) for BLOB and CLOB.
* Avoid ts escapes, which produce a datetime rather than a datetime2.
* Reintroduce the table names in rowtotext mode, and use empty
  strings for SQL Server.
* Use empty byte array rather than empty string for binary data.

Other changes:

* Revamp the executeUpdate swizzling to use \b and replaceAll.