### PR TITLE
Pass all but one test against Oracle.

### DIFF
--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -1494,7 +1494,7 @@ public class DatabaseAdaptorTest {
     moreEntries.put("db.modeOfOperation", "urlAndMetadataLister");
     moreEntries.put("docId.isUrl", "true");
     moreEntries.put("db.uniqueKey", "url:string");
-    moreEntries.put("db.everyDocIdSql", "select url from data");
+    moreEntries.put("db.everyDocIdSql", "select url from data order by url");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.updateSql", "select url from data");
     moreEntries.put("db.singleDocContentSql",
@@ -1509,8 +1509,8 @@ public class DatabaseAdaptorTest {
     assertEquals(messages.toString(), 1, messages.size());
     assertEquals(
         Arrays.asList(
-            new Record.Builder(new DocId("http://host/foo")).build(),
             new Record.Builder(new DocId("http://host/bar")).build(),
+            new Record.Builder(new DocId("http://host/foo")).build(),
             new Record.Builder(new DocId("http://host/foo%20bar")).build()),
         pusher.getRecords());
   }
@@ -1910,7 +1910,8 @@ public class DatabaseAdaptorTest {
     moreEntries.put("db.modeOfOperation", "urlAndMetadataLister");
     moreEntries.put("docId.isUrl", "true");
     moreEntries.put("db.uniqueKey", "url:string");
-    moreEntries.put("db.updateSql", "select url from data where ts >= ?");
+    moreEntries.put("db.updateSql",
+        "select url from data where ts >= ? order by url");
     // Required for validation, but not specific to this test.
     moreEntries.put("db.everyDocIdSql", "select url from data");
     moreEntries.put("db.singleDocContentSql",
@@ -1925,9 +1926,9 @@ public class DatabaseAdaptorTest {
     assertEquals(messages.toString(), 1, messages.size());
     assertEquals(
         Arrays.asList(
-            new Record.Builder(new DocId("http://host/foo"))
-            .setCrawlImmediately(true).build(),
             new Record.Builder(new DocId("http://host/bar"))
+            .setCrawlImmediately(true).build(),
+            new Record.Builder(new DocId("http://host/foo"))
             .setCrawlImmediately(true).build(),
             new Record.Builder(new DocId("http://host/foo%20bar"))
             .setCrawlImmediately(true).build()),

--- a/test/com/google/enterprise/adaptor/database/JdbcFixture.java
+++ b/test/com/google/enterprise/adaptor/database/JdbcFixture.java
@@ -47,6 +47,7 @@ class JdbcFixture {
   public static final String USER;
   public static final String PASSWORD;
   public static final String BOOLEAN;
+  public static final String INTEGER;
 
   private static ConcurrentLinkedDeque<AutoCloseable> openObjects =
       new ConcurrentLinkedDeque<>();
@@ -105,6 +106,7 @@ class JdbcFixture {
     PASSWORD = dbpassword;
     BOOLEAN = (DATABASE == Database.MYSQL || DATABASE == Database.SQLSERVER)
         ? "BIT" : "BOOLEAN";
+    INTEGER = (DATABASE == Database.ORACLE) ? "NUMERIC" : "INTEGER";
   }
 
   /**

--- a/test/com/google/enterprise/adaptor/database/JdbcFixture.java
+++ b/test/com/google/enterprise/adaptor/database/JdbcFixture.java
@@ -114,6 +114,16 @@ class JdbcFixture {
     return DATABASE == database;
   }
 
+  /** Gets a string value matching the corresponding JDBC d escape output. */
+  public static String d(String date) {
+    return is(Database.ORACLE) ? date + " 00:00:00.0" : date;
+  }
+
+  /** Gets a string value matching the corresponding JDBC t escape output. */
+  public static String t(String time) {
+    return is(Database.ORACLE) ? "1970-01-01 " + time + ".0" : time;
+  }
+
   /**
    * Gets a JDBC connection to the database.
    */
@@ -204,7 +214,11 @@ class JdbcFixture {
             break;
           case ORACLE:
             if (sql.startsWith("create table")) {
-              sql = sql.replaceAll("\\bvarbinary\\b", "raw(1024)");
+              sql = sql
+                  .replaceAll("\\bbigint\\b", "integer")
+                  .replaceAll("\\blongvarbinary\\b", "long raw")
+                  .replaceAll("\\btime\\b", "date")
+                  .replaceAll("\\bvarbinary\\b", "raw");
             }
             break;
           case SQLSERVER:

--- a/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
+++ b/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
@@ -126,7 +126,7 @@ public class TupleReaderTest {
         + "<table>"
         + "<table_rec>"
         + "<COLNAME SQLType=\""
-        + (is(ORACLE) ? "NUMERIC" : "INTEGER")
+        + JdbcFixture.INTEGER
         + "\">17</COLNAME>"
         + "</table_rec>"
         + "</table>"
@@ -145,7 +145,7 @@ public class TupleReaderTest {
         + "<table>"
         + "<table_rec>"
         + "<COLNAME SQLType=\""
-        + (is(ORACLE) ? "NUMERIC" : "INTEGER")
+        + JdbcFixture.INTEGER
         + "\" ISNULL=\"true\"/>"
         + "</table_rec>"
         + "</table>"
@@ -906,7 +906,7 @@ public class TupleReaderTest {
         + "<table>"
         + "<table_rec>"
         + "<ID SQLType=\""
-        + (is(ORACLE) ? "NUMERIC" : "INTEGER")
+        + JdbcFixture.INTEGER
         + "\">1</ID>"
         + "<NAME SQLType=\"VARCHAR\">file.txt</NAME>"
         + "<MODIFIED SQLType=\"TIMESTAMP\" ISNULL=\"true\"/>"

--- a/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
+++ b/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
@@ -16,6 +16,7 @@ package com.google.enterprise.adaptor.database;
 
 import static com.google.enterprise.adaptor.database.JdbcFixture.Database.H2;
 import static com.google.enterprise.adaptor.database.JdbcFixture.Database.MYSQL;
+import static com.google.enterprise.adaptor.database.JdbcFixture.Database.ORACLE;
 import static com.google.enterprise.adaptor.database.JdbcFixture.Database.SQLSERVER;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeQuery;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeQueryAndNext;
@@ -124,7 +125,9 @@ public class TupleReaderTest {
         + "<database>"
         + "<table>"
         + "<table_rec>"
-        + "<COLNAME SQLType=\"INTEGER\">17</COLNAME>"
+        + "<COLNAME SQLType=\""
+        + (is(ORACLE) ? "NUMERIC" : "INTEGER")
+        + "\">17</COLNAME>"
         + "</table_rec>"
         + "</table>"
         + "</database>";
@@ -141,7 +144,9 @@ public class TupleReaderTest {
         + "<database>"
         + "<table>"
         + "<table_rec>"
-        + "<COLNAME SQLType=\"INTEGER\" ISNULL=\"true\"/>"
+        + "<COLNAME SQLType=\""
+        + (is(ORACLE) ? "NUMERIC" : "INTEGER")
+        + "\" ISNULL=\"true\"/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";
@@ -152,6 +157,7 @@ public class TupleReaderTest {
 
   @Test
   public void testBoolean() throws Exception {
+    assumeFalse("BOOLEAN type not supported", is(ORACLE));
     executeUpdate("create table data(COLNAME " + JdbcFixture.BOOLEAN + ")");
     PreparedStatement ps =
         prepareStatement("insert into data(colname) values(?)");
@@ -174,6 +180,7 @@ public class TupleReaderTest {
 
   @Test
   public void testBoolean_null() throws Exception {
+    assumeFalse("BOOLEAN type not supported", is(ORACLE));
     executeUpdate("create table data(COLNAME " + JdbcFixture.BOOLEAN + ")");
     executeUpdate("insert into data(colname) values(null)");
     final String golden = ""
@@ -200,7 +207,7 @@ public class TupleReaderTest {
         + "<table>"
         + "<table_rec>"
         + "<COLNAME SQLType=\"CHAR\">"
-        + (is(SQLSERVER) ? "onevalue            " : "onevalue")
+        + (is(ORACLE) || is(SQLSERVER) ? "onevalue            " : "onevalue")
         + "</COLNAME>"
         + "</table_rec>"
         + "</table>"
@@ -320,7 +327,9 @@ public class TupleReaderTest {
         + "<database>"
         + "<table>"
         + "<table_rec>"
-        + "<COLNAME SQLType=\"VARBINARY\" encoding=\"base64binary\"/>"
+        + "<COLNAME SQLType=\"VARBINARY\" "
+        + (is(ORACLE) ? "ISNULL=\"true\"" : "encoding=\"base64binary\"")
+        + "/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";
@@ -354,7 +363,7 @@ public class TupleReaderTest {
     executeUpdate("create table data(COLNAME longvarbinary)");
     String sql = "insert into data(colname) values (?)";
     PreparedStatement ps = prepareStatement(sql);
-    ps.setBinaryStream(1, new ByteArrayInputStream(longvarbinaryData));
+    ps.setBytes(1, longvarbinaryData);
     assertEquals(1, ps.executeUpdate());
 
     String base64LongvarbinaryData =
@@ -383,7 +392,9 @@ public class TupleReaderTest {
         + "<database>"
         + "<table>"
         + "<table_rec>"
-        + "<COLNAME SQLType=\"LONGVARBINARY\" encoding=\"base64binary\"/>"
+        + "<COLNAME SQLType=\"LONGVARBINARY\" "
+        + (is(ORACLE) ? "ISNULL=\"true\"" : "encoding=\"base64binary\"")
+        + "/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";
@@ -412,6 +423,7 @@ public class TupleReaderTest {
 
   @Test
   public void testDate() throws Exception {
+    assumeFalse("DATE type not supported", is(ORACLE));
     executeUpdate("create table data(COLNAME date)");
     executeUpdate("insert into data(colname) values({d '2004-10-06'})");
     final String golden = ""
@@ -429,6 +441,7 @@ public class TupleReaderTest {
 
   @Test
   public void testDate_null() throws Exception {
+    assumeFalse("DATE type not supported", is(ORACLE));
     executeUpdate("create table data(COLNAME date)");
     executeUpdate("insert into data(colname) values(null)");
     final String golden = ""
@@ -446,6 +459,7 @@ public class TupleReaderTest {
 
   @Test
   public void testTime() throws Exception {
+    assumeFalse("TIME type not supported", is(ORACLE));
     executeUpdate("create table data(COLNAME time)");
     executeUpdate("insert into data(colname) values({t '09:15:30'})");
     // H2 returns a java.sql.Date with the date set to 1970-01-01.
@@ -475,6 +489,7 @@ public class TupleReaderTest {
 
   @Test
   public void testTime_null() throws Exception {
+    assumeFalse("TIME type not supported", is(ORACLE));
     executeUpdate("create table data(COLNAME time)");
     executeUpdate("insert into data(colname) values(null)");
     // H2 returns a java.sql.Date with the date set to 1970-01-01.
@@ -724,7 +739,9 @@ public class TupleReaderTest {
         + "<database>"
         + "<table>"
         + "<table_rec>"
-        + "<COLNAME SQLType=\"BLOB\" encoding=\"base64binary\"/>"
+        + "<COLNAME SQLType=\"BLOB\" "
+        + (is(ORACLE) ? "ISNULL=\"true\"" : "encoding=\"base64binary\"")
+        + "/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";
@@ -881,16 +898,18 @@ public class TupleReaderTest {
   @Test
   public void testMultipleTypes() throws Exception {
     executeUpdate(
-        "create table data(ID integer, NAME varchar(20), MODIFIED date)");
+        "create table data(ID integer, NAME varchar(20), MODIFIED timestamp)");
     executeUpdate(
         "insert into data(id, name, modified) values(1, 'file.txt', null)");
     final String golden = ""
         + "<database>"
         + "<table>"
         + "<table_rec>"
-        + "<ID SQLType=\"INTEGER\">1</ID>"
+        + "<ID SQLType=\""
+        + (is(ORACLE) ? "NUMERIC" : "INTEGER")
+        + "\">1</ID>"
         + "<NAME SQLType=\"VARCHAR\">file.txt</NAME>"
-        + "<MODIFIED SQLType=\"DATE\" ISNULL=\"true\"/>"
+        + "<MODIFIED SQLType=\"TIMESTAMP\" ISNULL=\"true\"/>"
         + "</table_rec>"
         + "</table>"
         + "</database>";

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -14,13 +14,16 @@
 
 package com.google.enterprise.adaptor.database;
 
+import static com.google.enterprise.adaptor.database.JdbcFixture.Database.ORACLE;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeQueryAndNext;
 import static com.google.enterprise.adaptor.database.JdbcFixture.executeUpdate;
+import static com.google.enterprise.adaptor.database.JdbcFixture.is;
 import static com.google.enterprise.adaptor.database.JdbcFixture.prepareStatement;
 import static com.google.enterprise.adaptor.database.UniqueKey.ColumnType;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.enterprise.adaptor.InvalidConfigurationException;
 
@@ -317,15 +320,15 @@ public class UniqueKeyTest {
   @Test
   public void testPreparingRetrieval() throws SQLException {
     executeUpdate("create table data("
-        + "numnum int, strstr varchar(20), tymestamp timestamp(3), date date, "
-        + "time time, longint bigint)");
+        + "numnum int, strstr varchar(20), tymestamp timestamp(3), dyte date, "
+        + "tyme time, longint bigint)");
 
     String sql = "insert into data("
-        + "numnum, strstr, tymestamp, date, time, longint)"
+        + "numnum, strstr, tymestamp, dyte, tyme, longint)"
         + " values (?, ?, ?, ?, ?, ?)";
     PreparedStatement ps = prepareStatement(sql);
     UniqueKey uk = newUniqueKey("numnum:int,strstr:string,"
-        + "tymestamp:timestamp,date:date,time:time,longint:long");
+        + "tymestamp:timestamp,dyte:date,tyme:time,longint:long");
     uk.setContentSqlValues(ps,
         "888/bluesky/1414701070212/2014-01-01/02:03:04/123");
     assertEquals(1, ps.executeUpdate());
@@ -334,8 +337,8 @@ public class UniqueKeyTest {
     assertEquals(888, rs.getInt("numnum"));
     assertEquals("bluesky", rs.getString("strstr"));
     assertEquals(new Timestamp(1414701070212L), rs.getTimestamp("tymestamp"));
-    assertEquals(Date.valueOf("2014-01-01"), rs.getDate("date"));
-    assertEquals(Time.valueOf("02:03:04"), rs.getTime("time"));
+    assertEquals(Date.valueOf("2014-01-01"), rs.getDate("dyte"));
+    assertEquals(Time.valueOf("02:03:04"), rs.getTime("tyme"));
     assertEquals(123L, rs.getLong("longint"));
   }
 
@@ -463,6 +466,7 @@ public class UniqueKeyTest {
 
   @Test
   public void testFuzzSlashesAndEscapes() throws Exception {
+    assumeFalse("Oracle treats empty strings as null", is(ORACLE));
     for (int fuzzCase = 0; fuzzCase < 1000; fuzzCase++) {
       String elem1 = makeSomeIdsWithJustSlashesAndEscapeChar();
       String elem2 = makeSomeIdsWithJustSlashesAndEscapeChar();
@@ -472,6 +476,7 @@ public class UniqueKeyTest {
 
   @Test
   public void testEmptiesPreserved() throws Exception {
+    assumeFalse("Oracle treats empty strings as null", is(ORACLE));
     testUniqueElementsRoundTrip("", "");
     testUniqueElementsRoundTrip("", "_stuff/");
     testUniqueElementsRoundTrip("_stuff/", "");


### PR DESCRIPTION
The exception is DatabaseAdaptorTest.testInitUniqueKeyOptionalTypes,
which uncovered b/64541388 and will be fixed separately.

* The DATE data type has both date and time components. Add t and d
  methods to JdbcFixture to mirror the resulting values from the
  JDBC escapes of the same names.
* Empty character and binary values as treated as null.
* The INTEGER data type is an alias for NUMBER(38) and returns as
  Types.NUMERIC rather than Types.INTEGER.
* BIT and BOOLEAN are not supported.
* Use integer for BIGINT.
* Use date for TIME (in some contexts).
* Use raw and long raw for VARBINARY and LONGVARBINARY.