### PR TITLE
Support unique key columns of type DECIMAL (b/64541388).

### DIFF
--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -385,6 +385,7 @@ class UniqueKey {
           case Types.BIGINT:
             type = ColumnType.LONG;
             break;
+          case Types.DECIMAL:
           case Types.NUMERIC:
             type = ColumnType.BIGDECIMAL;
             break;


### PR DESCRIPTION
Other changes:
* Skip the fuzz test on SQL Server, since it takes over 4 minutes.