### PR TITLE
Use getColumnTypeName more widely.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
+++ b/src/com/google/enterprise/adaptor/database/ResponseGenerator.java
@@ -15,6 +15,7 @@
 package com.google.enterprise.adaptor.database;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static com.google.enterprise.adaptor.database.DatabaseAdaptor.getColumnTypeName;
 
 import com.google.enterprise.adaptor.IOHelper;
 import com.google.enterprise.adaptor.InvalidConfigurationException;
@@ -317,7 +318,7 @@ public abstract class ResponseGenerator {
           case Types.STRUCT:
           case Types.JAVA_OBJECT:
             log.log(Level.FINEST, "Column type not supported for text: {0}",
-                columnType);
+                getColumnTypeName(columnType, rsMetaData, index));
             continue;
           default:
             try {
@@ -497,8 +498,9 @@ public abstract class ResponseGenerator {
       ResultSetMetaData rsMetaData = rs.getMetaData();
       int index = rs.findColumn(getContentColumnName());
       int columnType = rsMetaData.getColumnType(index);
+      String columnTypeName = getColumnTypeName(columnType, rsMetaData, index);
       log.log(Level.FINEST, "Content column name: {0}, Type: {1}",
-          new Object[] {getContentColumnName(), columnType});
+          new Object[] {getContentColumnName(), columnTypeName});
 
       OutputStream out = resp.getOutputStream();
       // This code supports *LOB, *CHAR, *BINARY, and SQLXML types only.
@@ -604,7 +606,7 @@ public abstract class ResponseGenerator {
           break;
         default:
           log.log(Level.WARNING, "Content column type not supported: {0}",
-              columnType);
+              columnTypeName);
           break;
       }
     }

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -18,6 +18,7 @@ import static java.util.Locale.US;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.enterprise.adaptor.InvalidConfigurationException;
+import com.google.enterprise.adaptor.database.DatabaseAdaptor.SqlType;
 
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
@@ -368,13 +369,13 @@ class UniqueKey {
      * @throws InvalidConfigurationException if a column's SQL type cannot be
      *     mapped to a ColumnType.
      */
-    Builder addColumnTypes(Map<String, Integer> sqlTypes) {
-      for (Map.Entry<String, Integer> entry : sqlTypes.entrySet()) {
+    Builder addColumnTypes(Map<String, SqlType> sqlTypes) {
+      for (Map.Entry<String, SqlType> entry : sqlTypes.entrySet()) {
         if (types.get(entry.getKey()) != null) {
           continue;
         }
         ColumnType type;
-        switch (entry.getValue()) {
+        switch (entry.getValue().getType()) {
           case Types.BIT:
           case Types.BOOLEAN:
           case Types.TINYINT:
@@ -408,9 +409,9 @@ class UniqueKey {
             type = ColumnType.TIMESTAMP;
             break;
           default:
-            String errmsg = "Invalid UniqueKey SQLtype '" + entry.getValue()
-                + "' for " + entry.getKey() + ". Please set an explicit key "
-                + "type in db.uniqueKey.";
+            String errmsg = "Invalid UniqueKey SQLtype '"
+                + entry.getValue().getName() + "' for " + entry.getKey()
+                + ". Please set an explicit key type in db.uniqueKey.";
             throw new InvalidConfigurationException(errmsg);
         }
         types.put(entry.getKey(), type);

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 import com.google.enterprise.adaptor.InvalidConfigurationException;
+import com.google.enterprise.adaptor.database.DatabaseAdaptor.SqlType;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -188,25 +189,25 @@ public class UniqueKeyTest {
 
   @Test
   public void testAddColumnTypes() {
-    Map<String, Integer> sqlTypes = new HashMap<>();
-    sqlTypes.put("BIT", Types.BIT);
-    sqlTypes.put("BOOLEAN", Types.BOOLEAN);
-    sqlTypes.put("TINYINT", Types.TINYINT);
-    sqlTypes.put("SMALLINT", Types.SMALLINT);
-    sqlTypes.put("INTEGER", Types.INTEGER);
-    sqlTypes.put("BIGINT", Types.BIGINT);
-    sqlTypes.put("DECIMAL", Types.DECIMAL);
-    sqlTypes.put("NUMERIC", Types.NUMERIC);
-    sqlTypes.put("CHAR", Types.CHAR);
-    sqlTypes.put("VARCHAR", Types.VARCHAR);
-    sqlTypes.put("LONGVARCHAR", Types.LONGVARCHAR);
-    sqlTypes.put("NCHAR", Types.NCHAR);
-    sqlTypes.put("NVARCHAR", Types.NVARCHAR);
-    sqlTypes.put("LONGNVARCHAR", Types.LONGNVARCHAR);
-    sqlTypes.put("DATALINK", Types.DATALINK);
-    sqlTypes.put("DATE", Types.DATE);
-    sqlTypes.put("TIME", Types.TIME);
-    sqlTypes.put("TIMESTAMP", Types.TIMESTAMP);
+    Map<String, SqlType> sqlTypes = new HashMap<>();
+    sqlTypes.put("BIT", new SqlType(Types.BIT));
+    sqlTypes.put("BOOLEAN", new SqlType(Types.BOOLEAN));
+    sqlTypes.put("TINYINT", new SqlType(Types.TINYINT));
+    sqlTypes.put("SMALLINT", new SqlType(Types.SMALLINT));
+    sqlTypes.put("INTEGER", new SqlType(Types.INTEGER));
+    sqlTypes.put("BIGINT", new SqlType(Types.BIGINT));
+    sqlTypes.put("DECIMAL", new SqlType(Types.DECIMAL));
+    sqlTypes.put("NUMERIC", new SqlType(Types.NUMERIC));
+    sqlTypes.put("CHAR", new SqlType(Types.CHAR));
+    sqlTypes.put("VARCHAR", new SqlType(Types.VARCHAR));
+    sqlTypes.put("LONGVARCHAR", new SqlType(Types.LONGVARCHAR));
+    sqlTypes.put("NCHAR", new SqlType(Types.NCHAR));
+    sqlTypes.put("NVARCHAR", new SqlType(Types.NVARCHAR));
+    sqlTypes.put("LONGNVARCHAR", new SqlType(Types.LONGNVARCHAR));
+    sqlTypes.put("DATALINK", new SqlType(Types.DATALINK));
+    sqlTypes.put("DATE", new SqlType(Types.DATE));
+    sqlTypes.put("TIME", new SqlType(Types.TIME));
+    sqlTypes.put("TIMESTAMP", new SqlType(Types.TIMESTAMP));
 
     Map<String, ColumnType> golden
         = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -239,8 +240,8 @@ public class UniqueKeyTest {
 
   @Test
   public void testAddColumnTypes_invalidType() {
-    Map<String, Integer> sqlTypes = new HashMap<>();
-    sqlTypes.put("blob", Types.BLOB);
+    Map<String, SqlType> sqlTypes = new HashMap<>();
+    sqlTypes.put("blob", new SqlType(Types.BLOB));
 
     UniqueKey.Builder builder = new UniqueKey.Builder("blob");
     thrown.expect(InvalidConfigurationException.class);


### PR DESCRIPTION
Move the method from TupleReader to DatabaseAdaptor unchanged.

Add a SqlType class to encapsulate the column type and name when
passing them from DatabaseAdaptor.verifyColumnNames to
UniqueKey.Builder.addColumnTypes.