### PR TITLE
Add tests for LONGVARBINARY and LONGVARCHAR.

### DIFF
--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -2256,6 +2256,53 @@ public class DatabaseAdaptorTest {
   }
 
   @Test
+  public void testMetadataColumns_longvarchar() throws Exception {
+    executeUpdate("create table data(id int, content longvarchar)");
+    executeUpdate("insert into data(id, content) values (1, 'hello world')");
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select id from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    expected.add("col2", "hello world");
+    assertEquals(expected, response.getMetadata());
+  }
+
+  @Test
+  public void testMetadataColumns_longvarcharNull() throws Exception {
+    executeUpdate("create table data(id int, content longvarchar)");
+    executeUpdate("insert into data(id) values (1)");
+
+    Map<String, String> configEntries = new HashMap<String, String>();
+    configEntries.put("db.uniqueKey", "ID:int");
+    configEntries.put("db.everyDocIdSql", "select id from data");
+    configEntries.put("db.singleDocContentSql",
+        "select * from data where id = ?");
+    configEntries.put("db.modeOfOperation", "rowToText");
+    configEntries.put("db.metadataColumns", "ID:col1, CONTENT:col2");
+
+    DatabaseAdaptor adaptor = getObjectUnderTest(configEntries);
+    MockRequest request = new MockRequest(new DocId("1"));
+    RecordingResponse response = new RecordingResponse();
+    adaptor.getDocContent(request, response);
+
+    Metadata expected = new Metadata();
+    expected.add("col1", "1");
+    assertEquals(expected, response.getMetadata());
+  }
+
+  @Test
   public void testMetadataColumns_date() throws Exception {
     executeUpdate("create table data(id integer, col date)");
     executeUpdate("insert into data(id, col) values(1001, {d '2004-10-06'})");

--- a/test/com/google/enterprise/adaptor/database/JdbcFixture.java
+++ b/test/com/google/enterprise/adaptor/database/JdbcFixture.java
@@ -212,8 +212,9 @@ class JdbcFixture {
           case MYSQL:
             if (sql.startsWith("create table")) {
               sql = sql
-                  .replaceAll("\\bclob\\b", "text")
-                  .replaceAll("\\blongvarbinary\\b", "long varbinary")
+                  .replaceAll("\\bclob\\b", "longtext")
+                  .replaceAll("\\blongvarbinary\\b", "mediumblob")
+                  .replaceAll("\\blongvarchar\\b", "mediumtext")
                   .replaceAll("\\btimestamp\\b(\\(\\d\\))?", "datetime$1 null");
             }
             break;
@@ -222,6 +223,7 @@ class JdbcFixture {
               sql = sql
                   .replaceAll("\\bbigint\\b", "integer")
                   .replaceAll("\\blongvarbinary\\b", "long raw")
+                  .replaceAll("\\blongvarchar\\b", "long")
                   .replaceAll("\\btime\\b", "date")
                   .replaceAll("\\bvarbinary\\b", "raw")
                   .replaceAll("\\bxml\\b", "xmltype");
@@ -232,6 +234,8 @@ class JdbcFixture {
               sql = sql
                   .replaceAll("\\bblob\\b", "varbinary(max)")
                   .replaceAll("\\bclob\\b", "varchar(max)")
+                  .replaceAll("\\blongvarbinary\\b", "image")
+                  .replaceAll("\\blongvarchar\\b", "text")
                   .replaceAll("\\btimestamp\\b", "datetime2");
             } else if (sql.startsWith("insert")) {
               // A ts escape is treated as a datetime rather than a

--- a/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
+++ b/test/com/google/enterprise/adaptor/database/TupleReaderTest.java
@@ -292,6 +292,42 @@ public class TupleReaderTest {
   }
 
   @Test
+  public void testLongvarchar() throws Exception {
+    assumeFalse("LONGVARCHAR type not supported", is(H2));
+    executeUpdate("create table data(COLNAME longvarchar)");
+    executeUpdate("insert into data(colname) values('onevalue')");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"LONGVARCHAR\">onevalue</COLNAME>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
+  public void testLongvarchar_null() throws Exception {
+    assumeFalse("LONGVARCHAR type not supported", is(H2));
+    executeUpdate("create table data(COLNAME longvarchar)");
+    executeUpdate("insert into data(colname) values(null)");
+    final String golden = ""
+        + "<database>"
+        + "<table>"
+        + "<table_rec>"
+        + "<COLNAME SQLType=\"LONGVARCHAR\" ISNULL=\"true\"/>"
+        + "</table_rec>"
+        + "</table>"
+        + "</database>";
+    ResultSet rs = executeQueryAndNext("select * from data");
+    String result = generateXml(rs);
+    assertEquals(golden, result);
+  }
+
+  @Test
   public void testBinary() throws Exception {
     byte[] binaryData = new byte[123];
     new Random().nextBytes(binaryData);
@@ -360,7 +396,7 @@ public class TupleReaderTest {
 
   @Test
   public void testLongvarbinary() throws Exception {
-    assumeFalse("LONGVARBINARY type not supported", is(H2) || is(SQLSERVER));
+    assumeFalse("LONGVARBINARY type not supported", is(H2));
     byte[] longvarbinaryData = new byte[12345];
     new Random().nextBytes(longvarbinaryData);
     executeUpdate("create table data(COLNAME longvarbinary)");
@@ -388,7 +424,7 @@ public class TupleReaderTest {
 
   @Test
   public void testLongvarbinary_empty() throws Exception {
-    assumeFalse("LONGVARBINARY type not supported", is(H2) || is(SQLSERVER));
+    assumeFalse("LONGVARBINARY type not supported", is(H2));
     executeUpdate("create table data(COLNAME longvarbinary)");
     executeUpdate("insert into data(colname) values('')");
     final String golden = ""
@@ -408,7 +444,7 @@ public class TupleReaderTest {
 
   @Test
   public void testLongvarbinary_null() throws Exception {
-    assumeFalse("LONGVARBINARY type not supported", is(H2) || is(SQLSERVER));
+    assumeFalse("LONGVARBINARY type not supported", is(H2));
     executeUpdate("create table data(COLNAME longvarbinary)");
     executeUpdate("insert into data(colname) values(null)");
     final String golden = ""


### PR DESCRIPTION
There are non-standard types that MySQL, Oracle, and SQL Server return
as LONGVARBINARY and LONGVARCHAR. Only H2 accepts the standard names,
but it returns them as BINARY and VARCHAR.