### PR TITLE
Trigger more javac lint warnings and fix them.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,7 +111,7 @@ lib/plexi submodule or add the the command line argument
       includeantruntime="false" encoding="utf-8"
       source="${compile.java.version}" target="${compile.java.version}">
       <bootclasspath path="${compile.java.bootclasspath}"/>
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg value="-Xlint"/>
       <classpath refid="adaptor.build.classpath"/>
     </javac>
 
@@ -121,7 +121,7 @@ lib/plexi submodule or add the the command line argument
       includeantruntime="true" encoding="utf-8"
       source="${compile.java.version}" target="${compile.java.version}">
       <bootclasspath path="${compile.java.bootclasspath}"/>
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg value="-Xlint"/>
       <classpath refid="junit.classpath"/>
       <include name="JUnitLogFixFormatter.java"/>
     </javac>
@@ -131,7 +131,7 @@ lib/plexi submodule or add the the command line argument
       includeantruntime="false" encoding="utf-8"
       source="${compile.java.version}" target="${compile.java.version}">
       <bootclasspath path="${compile.java.bootclasspath}"/>
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg value="-Xlint"/>
       <classpath refid="adaptor.build.classpath"/>
       <classpath location="${build-src.dir}"/>
       <classpath refid="junit.classpath"/>


### PR DESCRIPTION
This undoes the syntactic AutoCloseable changes in commit 6027217b,
but not the semantic changes made there, flushing unsent records.