### PR TITLE
Java 9 compatibility.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -34,6 +34,11 @@
   <property name="compile.java.newerClassname"
     value="java.lang.FunctionalInterface"/>
 
+  <!-- Use add-modules with Java 9 and higher. -->
+  <condition property="java.modules" value="" else="--add-modules java.se.ee">
+    <matches string="${ant.java.version}" pattern="^1\.[678]$"/>
+  </condition>
+
   <path id="adaptor.build.classpath">
     <pathelement location="${adaptor.jar}"/>
   </path>
@@ -255,6 +260,7 @@ lib/plexi submodule or add the the command line argument
 
   <target name="run" depends="build" description="Run adaptor">
     <java classpath="${build-src.dir}" fork="true" classname="${adaptor.class}">
+      <jvmarg line="${java.modules}"/>
       <classpath refid="adaptor.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
         value="logging.properties"/>
@@ -276,6 +282,7 @@ lib/plexi submodule or add the the command line argument
     <junit printsummary="yes"
       haltonfailure="${build.haltonfailure}" failureproperty="build.failure"
       forkmode="once" fork="true" dir="${basedir}" maxmemory="512m">
+      <jvmarg line="${java.modules}"/>
       <sysproperty key="net.sourceforge.cobertura.datafile"
         file="${build-instrument.dir}/cobertura.ser"/>
       <sysproperty key="build.properties" file="build.properties"/>

--- a/build.xml
+++ b/build.xml
@@ -35,7 +35,8 @@
     value="java.lang.FunctionalInterface"/>
 
   <!-- Use add-modules with Java 9 and higher. -->
-  <condition property="java.modules" value="" else="--add-modules java.se.ee">
+  <condition property="java.modules"
+      value="" else="--add-modules java.xml.bind">
     <matches string="${ant.java.version}" pattern="^1\.[678]$"/>
   </condition>
 

--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -217,8 +217,8 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     singleDocContentSql = cfg.getValue("db.singleDocContentSql");
     log.config("single doc content sql: " + singleDocContentSql);
 
-    Boolean includeAllColumnsAsMetadata = new Boolean(cfg.getValue(
-        "db.includeAllColumnsAsMetadata"));
+    boolean includeAllColumnsAsMetadata = Boolean.parseBoolean(
+        cfg.getValue("db.includeAllColumnsAsMetadata"));
     log.config("include all columns as metadata: "
         + includeAllColumnsAsMetadata);
 
@@ -278,7 +278,8 @@ public class DatabaseAdaptor extends AbstractAdaptor {
       log.config("aclPrincipalDelimiter: '" + aclPrincipalDelimiter + "'");
     }
 
-    disableStreaming = new Boolean(cfg.getValue("db.disableStreaming"));
+    disableStreaming =
+        Boolean.parseBoolean(cfg.getValue("db.disableStreaming"));
     log.config("disableStreaming: " + disableStreaming);
 
     String updateSql = cfg.getValue("db.updateSql");

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -272,7 +272,7 @@ public class DatabaseAdaptorTest {
     DatabaseAdaptor.loadResponseGenerator(config);
   }
 
-  private ResponseGenerator privateDummy(Map<String, String> config) {
+  private static ResponseGenerator privateDummy(Map<String, String> config) {
     return new DummyResponseGenerator(config);
   }
 


### PR DESCRIPTION
Deprecated features:

* new Boolean(String) (use Boolean.parseBoolean(String))

Java EE features:

* Add --add-modules java.se.ee; also requires Ant 1.9.4 or later

Behaviorial changes:

* Method.invoke checks happen in a different order (clarify test case)