### PR TITLE
A draft refactoring for ACLs based on #110.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -112,7 +112,7 @@ class UniqueKey {
     return sb.toString().substring(1);
   }
 
-  private void setSqlValues(PreparedStatement st, String uniqueId,
+  void setSqlValues(PreparedStatement st, String uniqueId,
       List<String> sqlCols) throws SQLException {
     // parse on / that isn't preceded by escape char _
     // (a / that is preceded by _ is part of column value)


### PR DESCRIPTION
* Remove persistent if statements, especially checking whether aclSql is null.
* Make it clear that there are two choices, whether aclSql is null,
  and whether we are coming from getDocContent or isUserAuthorized.
* Make most of the config decisions at init-time.

Notes:
* Indentation is incorrect to reduce diffs.
* Additional refactoring can eliminate the additional arguments for
  buildAcl and getAclFromDb by moving them inside of AclHandler.