### PR TITLE
First support for secondary metadata query.

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -128,6 +128,8 @@ public class DatabaseAdaptor extends AbstractAdaptor {
   private String everyDocIdSql;
   private String singleDocContentSql;
   private MetadataColumns metadataColumns;
+  private String extraMetadataSql;
+  private MetadataColumns extraMetadataColumns;
   private ResponseGenerator respGenerator;
   private String aclSql;
   private String aclPrincipalDelimiter;
@@ -150,6 +152,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     // when set to true, if "db.metadataColumns" is blank, it will use all
     // returned columns as metadata.
     config.addKey("db.includeAllColumnsAsMetadata", "false");
+    config.addKey("db.extraMetadataSql", "");
+    config.addKey("db.extraMetadataSqlParameters", "");
+    config.addKey("db.extraMetadataColumns", "");
     config.addKey("db.modeOfOperation", null);
     config.addKey("db.updateSql", "");
     config.addKey("db.aclSql", "");
@@ -234,6 +239,20 @@ public class DatabaseAdaptor extends AbstractAdaptor {
       }
     }
 
+    if (!isNullOrEmptyString(cfg.getValue("db.extraMetadataSql"))) {
+      extraMetadataSql = cfg.getValue("db.extraMetadataSql");
+      log.config("extra metadata sql: " + extraMetadataSql);
+      String extraMetadataColumnsConfig =
+          cfg.getValue("db.extraMetadataColumns");
+      if ("".equals(extraMetadataColumnsConfig)) {
+        extraMetadataColumns = null;
+        log.config("extra metadata columns: Use all columns in ResultSet");
+      } else {
+        extraMetadataColumns = new MetadataColumns(extraMetadataColumnsConfig);
+        log.config("extra metadata columns: " + extraMetadataColumns);
+      }
+    }
+
     modeOfOperation = cfg.getValue("db.modeOfOperation");
     log.config("mode of operation: " + modeOfOperation);
 
@@ -311,7 +330,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
         = new UniqueKey.Builder(cfg.getValue("db.uniqueKey"))
         .setDocIdIsUrl(docIdIsUrl)
         .setContentSqlColumns(cfg.getValue("db.singleDocContentSqlParameters"))
-        .setAclSqlColumns(cfg.getValue("db.aclSqlParameters"));
+        .setAclSqlColumns(cfg.getValue("db.aclSqlParameters"))
+        .setMetadataSqlColumns(
+            cfg.getValue("db.extraMetadataSqlParameters"));
 
     // Verify all column names.
     try (Connection conn = makeNewConnection()) {
@@ -331,6 +352,10 @@ public class DatabaseAdaptor extends AbstractAdaptor {
           verifyColumnNames(conn, "db.singleDocContentSql", singleDocContentSql,
               "db.metadataColumns", metadataColumns.keySet());
         }
+      }
+      if (extraMetadataColumns != null) {
+        verifyColumnNames(conn, "db.extraMetadataSql", extraMetadataSql,
+            "db.extraMetadataColumns", extraMetadataColumns.keySet());
       }
       if (respGenerator instanceof ResponseGenerator.SingleColumnContent) {
         ResponseGenerator.SingleColumnContent content =
@@ -477,6 +502,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
           builder.setDeleteFromIndex(true);
         } else if ("urlAndMetadataLister".equals(modeOfOperation)) {
           addMetadataToRecordBuilder(builder, rs);
+          if (extraMetadataSql != null) {
+            addExtraMetadataToRecordBuilder(builder, conn, id.getUniqueId());
+          }
         }
         DocIdPusher.Record record = builder.build();
         log.log(Level.FINEST, "doc id: {0}", id);
@@ -501,15 +529,10 @@ public class DatabaseAdaptor extends AbstractAdaptor {
   /*
    * Adds all specified metadata columns to the record or response being built.
    */
-  private void addMetadata(MetadataHandler meta, ResultSet rs)
-      throws SQLException, IOException {
+  private void addMetadata(MetadataHandler meta, ResultSet rs,
+      MetadataColumns rsMetadataColumns) throws SQLException, IOException {
     ResultSetMetaData rsMetaData = rs.getMetaData();
-    synchronized (this) {
-      if (metadataColumns == null) {
-        metadataColumns = new MetadataColumns(rsMetaData);
-      }
-    }
-    for (Map.Entry<String, String> entry : metadataColumns.entrySet()) {
+    for (Map.Entry<String, String> entry : rsMetadataColumns.entrySet()) {
       int index;
       try {
         index = rs.findColumn(entry.getKey());
@@ -633,25 +656,81 @@ public class DatabaseAdaptor extends AbstractAdaptor {
   @VisibleForTesting
   void addMetadataToRecordBuilder(final DocIdPusher.Record.Builder builder,
       ResultSet rs) throws SQLException, IOException {
+    synchronized (this) {
+      if (metadataColumns == null) {
+        metadataColumns = new MetadataColumns(rs.getMetaData());
+      }
+    }
     addMetadata(
         new MetadataHandler() {
           @Override public void addMetadata(String k, String v) {
             builder.addMetadata(k, v);
           }
         },
-        rs);
+        rs, metadataColumns);
   }
 
   @VisibleForTesting
   void addMetadataToResponse(final Response resp, ResultSet rs)
       throws SQLException, IOException {
+    synchronized (this) {
+      if (metadataColumns == null) {
+        metadataColumns = new MetadataColumns(rs.getMetaData());
+      }
+    }
     addMetadata(
         new MetadataHandler() {
           @Override public void addMetadata(String k, String v) {
             resp.addMetadata(k, v);
           }
         },
-        rs);
+        rs, metadataColumns);
+  }
+
+  private void addExtraMetadataToRecordBuilder(
+      final DocIdPusher.Record.Builder builder, Connection conn,
+      String uniqueId) throws SQLException, IOException {
+
+    try (PreparedStatement stmt = getExtraMetadataFromDb(conn, uniqueId);
+        ResultSet rs = stmt.executeQuery()) {
+      synchronized (this) {
+        if (extraMetadataColumns == null) {
+          extraMetadataColumns = new MetadataColumns(rs.getMetaData());
+        }
+      }
+      MetadataHandler handler = new MetadataHandler() {
+          @Override public void addMetadata(String k, String v) {
+            builder.addMetadata(k, v);
+          }
+        };
+      while (rs.next()) {
+        addMetadata(handler, rs, extraMetadataColumns);
+      }
+    } catch (SQLException ex) {
+      throw new IOException(ex);
+    }
+  }
+
+  private void addExtraMetadataToResponse(final Response resp, Connection conn,
+      String uniqueId) throws SQLException, IOException {
+    try (PreparedStatement stmt = getExtraMetadataFromDb(conn, uniqueId);
+        ResultSet rs = stmt.executeQuery()) {
+      synchronized (this) {
+        if (extraMetadataColumns == null) {
+          extraMetadataColumns = new MetadataColumns(rs.getMetaData());
+        }
+      }
+      MetadataHandler handler = new MetadataHandler() {
+          @Override public void addMetadata(String k, String v) {
+            resp.addMetadata(k, v);
+          }
+        };
+      while (rs.next()) {
+        addMetadata(handler, rs, extraMetadataColumns);
+      }
+    } catch (SQLException ex) {
+      throw new IOException(ex);
+    }
   }
 
   /** Gives the bytes of a document referenced with id. */
@@ -675,6 +754,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
       }
       // Generate response metadata first.
       addMetadataToResponse(resp, rs);
+      if (extraMetadataSql != null) {
+        addExtraMetadataToResponse(resp, conn, id.getUniqueId());
+      }
       // Generate Acl if aclSql is provided.
       if (aclSql != null) {
         resp.setAcl(getAcl(conn, id.getUniqueId()));
@@ -838,6 +920,14 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     return st;
   }
 
+  private PreparedStatement getExtraMetadataFromDb(Connection conn,
+      String uniqueId) throws SQLException {
+    PreparedStatement st = conn.prepareStatement(extraMetadataSql);
+    uniqueKey.setMetadataSqlValues(st, uniqueId);
+    log.log(Level.FINER, "about to get extra metadata: {0}",  uniqueId);
+    return st;
+  }
+
   /**
    * Mechanism that accepts stream of DocIdPusher.Record instances, buffers
    * them, and sends them when it has accumulated maximum allowed amount per
@@ -921,7 +1011,7 @@ public class DatabaseAdaptor extends AbstractAdaptor {
       throw new InvalidConfigurationException(errmsg, ex);
     }
   }
-  
+
   @VisibleForTesting
   static ResponseGenerator loadResponseGeneratorInternal(Method method,
       Map<String, String> config) {
@@ -1026,6 +1116,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
             builder.setDeleteFromIndex(true);
           } else if ("urlAndMetadataLister".equals(modeOfOperation)) {
             addMetadataToRecordBuilder(builder, rs);
+            if (extraMetadataSql != null) {
+              addExtraMetadataToRecordBuilder(builder, conn, id.getUniqueId());
+            }
           }
           DocIdPusher.Record record = builder.build();
           log.log(Level.FINEST, "doc id: {0}", id);

--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -706,22 +706,22 @@ public class DatabaseAdaptor extends AbstractAdaptor {
   private void addExtraMetadataToRecordBuilder(
       final DocIdPusher.Record.Builder builder, Connection conn,
       String uniqueId) throws SQLException, IOException {
-    MetadataHandler handler = new MetadataHandler() {
-        @Override public void addMetadata(String k, String v) {
-          builder.addMetadata(k, v);
-        }
-      };
-    addExtraMetadata(conn, uniqueId, handler);
+    addExtraMetadata(conn, uniqueId,
+        new MetadataHandler() {
+          @Override public void addMetadata(String k, String v) {
+            builder.addMetadata(k, v);
+          }
+        });
   }
 
   private void addExtraMetadataToResponse(final Response resp, Connection conn,
       String uniqueId) throws SQLException, IOException {
-    MetadataHandler handler = new MetadataHandler() {
-        @Override public void addMetadata(String k, String v) {
-          resp.addMetadata(k, v);
-        }
-      };
-    addExtraMetadata(conn, uniqueId, handler);
+    addExtraMetadata(conn, uniqueId,
+        new MetadataHandler() {
+          @Override public void addMetadata(String k, String v) {
+            resp.addMetadata(k, v);
+          }
+        });
   }
 
   private void addExtraMetadata(Connection conn, String uniqueId,

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -117,6 +117,15 @@ class UniqueKey {
   private void setSqlValues(PreparedStatement st, String uniqueId,
       List<String> sqlCols) throws SQLException {
     Map<String, String> zip = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    // Parameters to SQL queries are taken from the unique id. When reading extraMetadata
+    // when docIdIsUrl is true, we're now passing the unique id to this method for the
+    // first time. Don't try to split the id; we know it must be a single unique string.
+
+    // TODO(aptls): while this may be OK in that we don't want to try to split the id when
+    // we know it's a URL, the underlying use case of using value(s) from the unique id to
+    // retrieve the extra metadata might not want to have to use this URL as the metadata
+    // key. We want to change this to be able to retrieve the metadata key value(s) from
+    // the doc id or content result set instead of the key.
     if (docIdIsUrl) {
       zip.put(docIdSqlCols.get(0), uniqueId);
     } else {
@@ -294,6 +303,7 @@ class UniqueKey {
       docIdSqlCols = Collections.unmodifiableList(tmpNames);
       contentSqlCols = docIdSqlCols;
       aclSqlCols = docIdSqlCols;
+      metadataSqlCols = docIdSqlCols;
     }
 
     /**
@@ -359,7 +369,7 @@ class UniqueKey {
 
     Builder setMetadataSqlColumns(String metadataSqlColumns)
         throws InvalidConfigurationException {
-      if (null == metadataSqlColumns) {
+      if (metadataSqlColumns == null) {
         throw new NullPointerException();
       }
       if (!metadataSqlColumns.trim().isEmpty()) {

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -117,15 +117,18 @@ class UniqueKey {
   private void setSqlValues(PreparedStatement st, String uniqueId,
       List<String> sqlCols) throws SQLException {
     Map<String, String> zip = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    // Parameters to SQL queries are taken from the unique id. When reading extraMetadata
-    // when docIdIsUrl is true, we're now passing the unique id to this method for the
-    // first time. Don't try to split the id; we know it must be a single unique string.
+    // Parameters to SQL queries are taken from the unique id. When
+    // reading extraMetadata when docIdIsUrl is true, we're now
+    // passing the unique id to this method for the first time. Don't
+    // try to split the id; we know it must be a single unique string.
 
-    // TODO(aptls): while this may be OK in that we don't want to try to split the id when
-    // we know it's a URL, the underlying use case of using value(s) from the unique id to
-    // retrieve the extra metadata might not want to have to use this URL as the metadata
-    // key. We want to change this to be able to retrieve the metadata key value(s) from
-    // the doc id or content result set instead of the key.
+    // TODO(aptls): while this may be OK in that we don't want to try
+    // to split the id when we know it's a URL, the underlying use
+    // case of using value(s) from the unique id to retrieve the extra
+    // metadata might not want to have to use this URL as the metadata
+    // key. We want to change this to be able to retrieve the metadata
+    // key value(s) from the doc id or content result set instead of
+    // the key.
     if (docIdIsUrl) {
       zip.put(docIdSqlCols.get(0), uniqueId);
     } else {

--- a/src/com/google/enterprise/adaptor/database/UniqueKey.java
+++ b/src/com/google/enterprise/adaptor/database/UniqueKey.java
@@ -116,18 +116,22 @@ class UniqueKey {
 
   private void setSqlValues(PreparedStatement st, String uniqueId,
       List<String> sqlCols) throws SQLException {
-    // parse on / that isn't preceded by escape char _
-    // (a / that is preceded by _ is part of column value)
-    String parts[] = uniqueId.split("(?<!_)/", -1);
-    if (parts.length != docIdSqlCols.size()) {
-      String errmsg = "Wrong number of values for primary key: "
-          + "id: " + uniqueId + ", parts: " + Arrays.asList(parts);
-      throw new IllegalStateException(errmsg);
-    }
     Map<String, String> zip = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    for (int i = 0; i < parts.length; i++) {
-      String columnValue = decodeSlashInData(parts[i]);
-      zip.put(docIdSqlCols.get(i), columnValue);
+    if (docIdIsUrl) {
+      zip.put(docIdSqlCols.get(0), uniqueId);
+    } else {
+      // parse on / that isn't preceded by escape char _
+      // (a / that is preceded by _ is part of column value)
+      String parts[] = uniqueId.split("(?<!_)/", -1);
+      if (parts.length != docIdSqlCols.size()) {
+        String errmsg = "Wrong number of values for primary key: "
+            + "id: " + uniqueId + ", parts: " + Arrays.asList(parts);
+        throw new IllegalStateException(errmsg);
+      }
+      for (int i = 0; i < parts.length; i++) {
+        String columnValue = decodeSlashInData(parts[i]);
+        zip.put(docIdSqlCols.get(i), columnValue);
+      }
     }
     for (int i = 0; i < sqlCols.size(); i++) {
       String colName = sqlCols.get(i);
@@ -224,8 +228,8 @@ class UniqueKey {
 
   @Override
   public String toString() {
-    return "UniqueKey(" + docIdSqlCols + "," + types + ","
-        + contentSqlCols + "," + aclSqlCols + "," + metadataSqlCols + ")";
+    return "UniqueKey(" + docIdSqlCols + "," + types + "," + contentSqlCols + ","
+        + aclSqlCols + "," + metadataSqlCols + ")";
   }
 
   /** Builder to create instances of {@code UniqueKey}. */

--- a/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/database/DatabaseAdaptorTest.java
@@ -1727,7 +1727,6 @@ public class DatabaseAdaptorTest {
         pusher.getRecords());
   }
 
-
   @Test
   public void testGetDocIds_nullUniqueKey() throws Exception {
     executeUpdate("create table data(id integer, other varchar(20))");

--- a/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
+++ b/test/com/google/enterprise/adaptor/database/UniqueKeyTest.java
@@ -95,6 +95,12 @@ public class UniqueKeyTest {
   }
 
   @Test
+  public void testNullMetadataCols() {
+    thrown.expect(NullPointerException.class);
+    new UniqueKey.Builder("num:int").setMetadataSqlColumns(null);
+  }
+
+  @Test
   public void testSingleInt() {
     UniqueKey.Builder builder = new UniqueKey.Builder("numnum:int");
     assertEquals(asList("numnum"), builder.getDocIdSqlColumns());
@@ -185,6 +191,15 @@ public class UniqueKeyTest {
         "Unknown column 'IsStranger' from db.aclSqlParameters");
     new UniqueKey.Builder("numnum:int,strstr:string")
         .setAclSqlColumns("numnum,IsStranger,strstr");
+  }
+
+  @Test
+  public void testUnknownMetadataCol() {
+    thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage(
+        "Unknown column 'IsStranger' from db.extraMetadataSqlParameters");
+    new UniqueKey.Builder("numnum:int,strstr:string")
+        .setMetadataSqlColumns("numnum,IsStranger,strstr");
   }
 
   @Test
@@ -719,6 +734,26 @@ public class UniqueKeyTest {
       UniqueKey.Builder testBuilder = new UniqueKey.Builder(ukDecl)
           .setAclSqlColumns(colDecl);
       assertEquals(goldenNames, testBuilder.getAclSqlColumns());
+    }
+  }
+
+  @Test
+  public void testSpacesBetweenMetadataSqlCols() {
+    String ukDecl = "numnum:int,strstr:string";
+    UniqueKey.Builder builder = new UniqueKey.Builder(ukDecl)
+        .setMetadataSqlColumns("numnum,numnum,strstr,numnum,strstr");
+    List<String> goldenNames = builder.getMetadataSqlColumns();
+
+    List<String> testDecls = asList(
+        "numnum ,numnum,strstr,numnum,strstr",
+        "numnum, numnum,strstr,numnum,strstr",
+        "numnum , numnum,strstr,numnum,strstr",
+        "numnum  ,   numnum,strstr,numnum,strstr",
+        "numnum  ,   numnum , strstr   ,  numnum,strstr");
+    for (String colDecl : testDecls) {
+      UniqueKey.Builder testBuilder = new UniqueKey.Builder(ukDecl)
+          .setMetadataSqlColumns(colDecl);
+      assertEquals(goldenNames, testBuilder.getMetadataSqlColumns());
     }
   }
 }


### PR DESCRIPTION
Add support for a secondary SQL query to retrieve metadata from a
second table. This first implementation supports a model in which
metadata is stored in a second table in one or more rows keyed by
some unique value from the original doc record. Three new config
parameters are used: db.extraMetadataSql (to specify the query),
db.extraMetadataSqlParameters (to list the column names whose
values are used as parameters in db.extraMetadataSql), and
optionally db.extraMetadataColumns (to specify the columns from
the metadata result set to use).

The addMetadata/addMetadataTo* methods were refactored a bit to
allow addMetadata to be used for the extraMetadata table as well.

The current implementation requires the key into the metadata
table to be part of the doc's unique key, but this is not
necessarily a requirement to support retrieving metadata from a
second table.

The config parameters and new methods use "extraMetadata" in
their names to identify them as applying to this secondary
query. The prior existence of "db.metadataColumns" as a parameter
applying to the primary doc query made new parameter names
starting with "db.metadata*" feel confusing. A better naming
scheme might be nice.

This implementation is expected to be extended with support for
other metadata structures, possibly in a manner similar to the
ResponseGenerator, so that should be taken into account when
thinking about config parameter names.