### PR TITLE
Allow empty db.everyDocIdSql again (b/73905665).

### DIFF
--- a/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
+++ b/src/com/google/enterprise/adaptor/database/DatabaseAdaptor.java
@@ -275,8 +275,8 @@ public class DatabaseAdaptor extends AbstractAdaptor {
     }
 
     if (everyDocIdSql.isEmpty()) {
-      throw new InvalidConfigurationException(
-          "db.everyDocIdSql cannot be an empty string");
+      log.warning("db.everyDocIdSql cannot be an empty string"
+          + " if full listings are enabled.");
     }
 
     if (!isNullOrEmptyString(cfg.getValue("db.aclSql"))) {
@@ -463,6 +463,9 @@ public class DatabaseAdaptor extends AbstractAdaptor {
   @Override
   public void getDocIds(DocIdPusher pusher) throws IOException,
       InterruptedException {
+    if (everyDocIdSql.isEmpty()) {
+      throw new IOException("db.everyDocIdSql cannot be an empty string");
+    }
     BufferedPusher outstream = new BufferedPusher(pusher);
     try (Connection conn = makeNewConnection();
         PreparedStatement stmt = getStreamFromDb(conn, everyDocIdSql);


### PR DESCRIPTION
This was a regression in v4.1.3 when extra validation was added.
Such a config is a rare but valid corner case.